### PR TITLE
Allow use of WSS (web socket secure)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,17 +22,23 @@ type Client struct {
 	rpc jsonrpc2.JSONRPC2
 }
 
+type Config struct {
+	Url      string
+	Username string
+	Password string
+}
+
 var dialer = gorillawebsocket.Dialer{
 	ReadBufferSize:  MaxMessageSize,
 	WriteBufferSize: MaxMessageSize,
 }
 
 func NewClient(params ...string) (*Client, error) {
-	var hostname string
+	var url string
 	var username string
 	var password string
-	if v := os.Getenv("XOA_HOST"); v != "" {
-		hostname = v
+	if v := os.Getenv("XOA_URL"); v != "" {
+		url = v
 	}
 	if v := os.Getenv("XOA_USER"); v != "" {
 		username = v
@@ -41,11 +47,12 @@ func NewClient(params ...string) (*Client, error) {
 		password = v
 	}
 	if len(params) == 3 {
-		hostname = params[0]
+		url = params[0]
 		username = params[1]
 		password = params[2]
 	}
-	ws, _, err := dialer.Dial(fmt.Sprintf("ws://%s/api/", hostname), http.Header{})
+
+	ws, _, err := dialer.Dial(fmt.Sprintf("%s/api/", url), http.Header{})
 
 	if err != nil {
 		return nil, err

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -18,8 +18,9 @@ If you're building the provider, follow the instructions to install it as a http
 ```hcl
 # Configure the XenServer Provider
 provider "xenorchestra" {
-  host     = "<xoa-hostname>" # Or set XOA_HOST environment variable
-  username = "<username>"     # Or set XOA_USER environment variable
-  password = "<password>"     # Or set XOA_PASSWORD environment variable
+  # Must be ws or wss
+  url      = "ws://hostname-of-server" # Or set XOA_URL environment variable
+  username = "<username>"              # Or set XOA_USER environment variable
+  password = "<password>"              # Or set XOA_PASSWORD environment variable
 }
 ```

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -1,6 +1,7 @@
 package xoa
 
 import (
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -8,10 +9,10 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"host": &schema.Schema{
+			"url": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("XOA_HOST", nil),
+				DefaultFunc: schema.EnvDefaultFunc("XOA_URL", nil),
 				Description: "Hostname of the xoa router",
 			},
 			"username": &schema.Schema{
@@ -41,13 +42,13 @@ func Provider() terraform.ResourceProvider {
 }
 
 func xoaConfigure(d *schema.ResourceData) (c interface{}, err error) {
-	address := d.Get("host").(string)
+	address := d.Get("url").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
-	c = xoaConfig{
-		host:     address,
-		username: username,
-		password: password,
+	c = client.Config{
+		Url:      address,
+		Username: username,
+		Password: password,
 	}
-	return
+	return c, nil
 }

--- a/xoa/provider_test.go
+++ b/xoa/provider_test.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("XOA_HOST"); v == "" {
-		t.Fatal("The XOA_HOST environment variable must be set")
+	if v := os.Getenv("XOA_URL"); v == "" {
+		t.Fatal("The XOA_URL environment variable must be set")
 	}
 	if v := os.Getenv("XOA_USER"); v == "" {
 		t.Fatal("The XOA_USER environment variable must be set")

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -174,12 +174,6 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-type xoaConfig struct {
-	host     string
-	username string
-	password string
-}
-
 func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 	xoaId := d.Id()
 	c, err := client.NewClient()


### PR DESCRIPTION
This small refactor allows using WSS. Previously only plaintext websockets worked since the protocol was hardcoded (since that's all I was using at the time). This is to address the first part of #10.


Since I don't have CI setup for `make testacc` yet here is my passing test run.

```
ddelnano@ddelnano-desktop:~/code/terraform-provider-xenorchestra$ make testacc
TF_ACC=1 go test ./... -v
# github.com/ddelnano/terraform-provider-xenorchestra/client [github.com/ddelnano/terraform-provider-xenorchestra/client.test]
client/client.go:50:3: undefined: hostname
# github.com/ddelnano/terraform-provider-xenorchestra/client
client/client.go:50:3: undefined: hostname
FAIL    github.com/ddelnano/terraform-provider-xenorchestra/client [build failed]
FAIL    github.com/ddelnano/terraform-provider-xenorchestra/xoa [build failed]
Makefile:16: recipe for target 'testacc' failed
make: *** [testacc] Error 2
ddelnano@ddelnano-desktop:~/code/terraform-provider-xenorchestra$ make testacc
TF_ACC=1 go test ./... -v
?       github.com/ddelnano/terraform-provider-xenorchestra     [no test files]
=== RUN   TestGetPIFByDevice
--- PASS: TestGetPIFByDevice (0.42s)
=== RUN   TestGetTemplate
--- PASS: TestGetTemplate (0.58s)
=== RUN   TestThatUnmarshalingWorks
--- PASS: TestThatUnmarshalingWorks (0.00s)
=== RUN   TestUnmarshalingVmObject
--- PASS: TestUnmarshalingVmObject (0.00s)
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/client      1.011s
=== RUN   TestAccXenorchestraDataSource_pif
--- PASS: TestAccXenorchestraDataSource_pif (1.62s)
=== RUN   TestAccXenorchestraDataSource_template
--- PASS: TestAccXenorchestraDataSource_template (1.51s)
=== RUN   TestAccXenorchestraCloudConfig_readAfterDelete
--- PASS: TestAccXenorchestraCloudConfig_readAfterDelete (1.11s)
=== RUN   TestAccXenorchestraCloudConfig_create
--- PASS: TestAccXenorchestraCloudConfig_create (0.89s)
=== RUN   TestAccXenorchestraCloudConfig_updateName
--- PASS: TestAccXenorchestraCloudConfig_updateName (1.49s)
=== RUN   TestAccXenorchestraCloudConfig_updateTemplate
--- PASS: TestAccXenorchestraCloudConfig_updateTemplate (1.53s)
=== RUN   TestAccXenorchestraCloudConfig_import
--- PASS: TestAccXenorchestraCloudConfig_import (1.04s)
=== RUN   TestAccXenorchestraVm_create
VM params map[string]interface {}{"CPUs":1, "VIFs":[]map[string]string{map[string]string{"network":"d225cf00-36f8-e6d6-6a29-02636d4de56b"}}, "bootAfterCreate":true, "cloudConfig":"template", "coreOs":false, "cpuCap":interface {}(nil), "cpuWeight":interface {}(nil), "existingDisks":map[string]interface {}{"0":map[string]interface {}{"$SR":"7f469400-4a2b-5624-cf62-61e522e50ea1", "name_label":"Ubuntu Bionic Beaver 18.04_imavo", "size":32212254720}}, "memoryMax":1073733632, "name_description":"description", "name_label":"Name", "template":"2dd0373e-0ed5-7413-a57f-1958d03b698c"}--- PASS: TestAccXenorchestraVm_create (69.12s)
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa 78.325s
```