### PR TITLE
Make sure the provider block and environment variables can configure the terraform provider

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,7 +33,7 @@ var dialer = gorillawebsocket.Dialer{
 	WriteBufferSize: MaxMessageSize,
 }
 
-func NewClient(params ...string) (*Client, error) {
+func GetConfigFromEnv() Config {
 	var url string
 	var username string
 	var password string
@@ -46,11 +46,17 @@ func NewClient(params ...string) (*Client, error) {
 	if v := os.Getenv("XOA_PASSWORD"); v != "" {
 		password = v
 	}
-	if len(params) == 3 {
-		url = params[0]
-		username = params[1]
-		password = params[2]
+	return Config{
+		Url:      url,
+		Username: username,
+		Password: password,
 	}
+}
+
+func NewClient(config Config) (*Client, error) {
+	url := config.Url
+	username := config.Username
+	password := config.Password
 
 	ws, _, err := dialer.Dial(fmt.Sprintf("%s/api/", url), http.Header{})
 

--- a/client/pif_test.go
+++ b/client/pif_test.go
@@ -3,7 +3,7 @@ package client
 import "testing"
 
 func TestGetPIFByDevice(t *testing.T) {
-	c, err := NewClient()
+	c, err := NewClient(GetConfigFromEnv())
 
 	if err != nil {
 		t.Errorf("failed to create client with error: %v", err)

--- a/client/template_test.go
+++ b/client/template_test.go
@@ -26,7 +26,7 @@ func TestGetTemplate(t *testing.T) {
 		},
 	}
 
-	c, err := NewClient()
+	c, err := NewClient(GetConfigFromEnv())
 
 	if err != nil {
 		t.Errorf("failed to create client: %v", err)

--- a/xoa/data_source_xenorchestra_pif.go
+++ b/xoa/data_source_xenorchestra_pif.go
@@ -38,7 +38,8 @@ func dataSourceXoaPIF() *schema.Resource {
 }
 
 func dataSourcePIFRead(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return err

--- a/xoa/data_source_xenorchestra_template.go
+++ b/xoa/data_source_xenorchestra_template.go
@@ -22,7 +22,8 @@ func dataSourceXoaTemplate() *schema.Resource {
 }
 
 func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return err

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -36,17 +36,16 @@ func Provider() terraform.ResourceProvider {
 			"xenorchestra_template": dataSourceXoaTemplate(),
 			"xenorchestra_pif":      dataSourceXoaPIF(),
 		},
-		// TODO: do i need a configure func?
 		ConfigureFunc: xoaConfigure,
 	}
 }
 
 func xoaConfigure(d *schema.ResourceData) (c interface{}, err error) {
-	address := d.Get("url").(string)
+	url := d.Get("url").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
 	c = client.Config{
-		Url:      address,
+		Url:      url,
 		Username: username,
 		Password: password,
 	}

--- a/xoa/resource_xenorchestra_cloud_config.go
+++ b/xoa/resource_xenorchestra_cloud_config.go
@@ -30,42 +30,45 @@ func resourceCloudConfigRecord() *schema.Resource {
 }
 
 func resourceCloudConfigCreate(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 	if err != nil {
 		return err
 	}
 
-	config, err := c.CreateCloudConfig(d.Get("name").(string), d.Get("template").(string))
+	cloud_config, err := c.CreateCloudConfig(d.Get("name").(string), d.Get("template").(string))
 	if err != nil {
 		return err
 	}
-	d.SetId(config.Id)
+	d.SetId(cloud_config.Id)
 	return nil
 }
 
 func resourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 	if err != nil {
 		return err
 	}
 
-	config, err := c.GetCloudConfig(d.Id())
+	cloud_config, err := c.GetCloudConfig(d.Id())
 	if err != nil {
 		return err
 	}
 
-	if config == nil {
+	if cloud_config == nil {
 		d.SetId("")
 		return nil
 	}
 
-	d.Set("name", config.Name)
-	d.Set("template", config.Template)
+	d.Set("name", cloud_config.Name)
+	d.Set("template", cloud_config.Template)
 	return nil
 }
 
 func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 	if err != nil {
 		return err
 	}
@@ -81,17 +84,18 @@ func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
 
 func CloudConfigImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 	if err != nil {
 		return nil, err
 	}
 
-	config, err := c.GetCloudConfig(d.Id())
+	cloud_config, err := c.GetCloudConfig(d.Id())
 
 	if err != nil {
 		return nil, err
 	}
-	d.Set("name", config.Name)
-	d.Set("template", config.Template)
+	d.Set("name", cloud_config.Name)
+	d.Set("template", cloud_config.Template)
 	return []*schema.ResourceData{d}, nil
 }

--- a/xoa/resource_xenorchestra_cloud_config_test.go
+++ b/xoa/resource_xenorchestra_cloud_config_test.go
@@ -167,7 +167,7 @@ func testAccCloudConfigExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("No CloudConfig Id is set")
 		}
 
-		c, err := client.NewClient()
+		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func testAccCheckXenorchestraCloudConfigDestroyNow(resourceName string) resource
 			return fmt.Errorf("No CloudConfig Id is set")
 		}
 
-		c, err := client.NewClient()
+		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func testAccCheckXenorchestraCloudConfigDestroyNow(resourceName string) resource
 }
 
 func testAccCheckXenorchestraCloudConfigDestroy(s *terraform.State) error {
-	c, err := client.NewClient()
+	c, err := client.NewClient(client.GetConfigFromEnv())
 	if err != nil {
 		return err
 	}

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -124,7 +124,8 @@ func resourceRecord() *schema.Resource {
 }
 
 func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return err
@@ -176,7 +177,8 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 	xoaId := d.Id()
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return err
@@ -194,7 +196,8 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return err
@@ -212,7 +215,8 @@ func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
 func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	xoaId := d.Id()
 
-	c, err := client.NewClient()
+	config := m.(client.Config)
+	c, err := client.NewClient(config)
 
 	if err != nil {
 		return nil, err

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -66,7 +66,7 @@ func testAccVm_import(t *testing.T) {
 
 // TODO: Add unit tests
 func testAccCheckXenorchestraVmDestroy(s *terraform.State) error {
-	c, err := client.NewClient()
+	c, err := client.NewClient(client.GetConfigFromEnv())
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func testAccVmExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("No Vm Id is set")
 		}
 
-		c, err := client.NewClient()
+		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes #12.

The local acceptance test run

```
ddelnano@ddelnano-desktop:~/code/terraform-provider-xenorchestra$ make testacc
TF_ACC=1 go test ./... -v
?       github.com/ddelnano/terraform-provider-xenorchestra     [no test files]
=== RUN   TestGetPIFByDevice
--- PASS: TestGetPIFByDevice (0.34s)
=== RUN   TestGetTemplate
--- PASS: TestGetTemplate (0.60s)
=== RUN   TestThatUnmarshalingWorks
--- PASS: TestThatUnmarshalingWorks (0.00s)
=== RUN   TestUnmarshalingVmObject
--- PASS: TestUnmarshalingVmObject (0.00s)
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/client      (cached)
=== RUN   TestAccXenorchestraDataSource_pif
--- PASS: TestAccXenorchestraDataSource_pif (1.42s)
=== RUN   TestAccXenorchestraDataSource_template
--- PASS: TestAccXenorchestraDataSource_template (1.51s)
=== RUN   TestAccXenorchestraCloudConfig_readAfterDelete
--- PASS: TestAccXenorchestraCloudConfig_readAfterDelete (1.09s)
=== RUN   TestAccXenorchestraCloudConfig_create
--- PASS: TestAccXenorchestraCloudConfig_create (0.94s)
=== RUN   TestAccXenorchestraCloudConfig_updateName
--- PASS: TestAccXenorchestraCloudConfig_updateName (1.80s)
=== RUN   TestAccXenorchestraCloudConfig_updateTemplate
--- PASS: TestAccXenorchestraCloudConfig_updateTemplate (1.55s)
=== RUN   TestAccXenorchestraCloudConfig_import
--- PASS: TestAccXenorchestraCloudConfig_import (1.05s)
=== RUN   TestAccXenorchestraVm_create
VM params map[string]interface {}{"CPUs":1, "VIFs":[]map[string]string{map[string]string{"network":"d225cf00-36f8-e6d6-6a29-02636d4de56b"}}, "bootAfterCreate":true, "cloudConfig":"template", "coreOs":false, "cpuCap":interface {}(nil), "cpuWeight":interface {}(nil), "existingDisks":map[string]interface {}{"0":map[string]interface {}{"$SR":"7f469400-4a2b-5624-cf62-61e522e50ea1", "name_label":"Ubuntu Bionic Beaver 18.04_imavo", "size":32212254720}}, "memoryMax":1073733632, "name_description":"description", "name_label":"Name", "template":"2dd0373e-0ed5-7413-a57f-1958d03b698c"}--- PASS: TestAccXenorchestraVm_create (52.83s)
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa 62.193s
```

I also tried the provider out locally just to prove it worked.