### PR TITLE
Update all calls to xo.getAllObjects to use the correct arguments

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -102,7 +102,9 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		panic(fmt.Sprintf("XO client does not support type: %v", t))
 	}
 	params := map[string]interface{}{
-		"type": xoApiType,
+		"filter": map[string]string{
+			"type": xoApiType,
+		},
 	}
 	var objsRes struct {
 		Objects map[string]interface{} `json:"-"`

--- a/client/vm.go
+++ b/client/vm.go
@@ -113,7 +113,9 @@ func (c *Client) DeleteVm(id string) error {
 
 func (c *Client) GetVm(id string) (*Vm, error) {
 	params := map[string]interface{}{
-		"type": "VM",
+		"filter": map[string]string{
+			"type": "VM",
+		},
 	}
 	var objsRes allObjectResponse
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@ The provider needs to be configured with the proper credentials before it can be
 
 ** Terraform 0.12+
 ** Go 1.12 (to build the provider plugin)
-** Xen Orchestra 5.31.2+
+** Xen Orchestra 5.50.1
 
 == Using the provider
 


### PR DESCRIPTION
This fixes #25. See that issue for more details.

## Testing
- Upgraded my instance of xo-server to 5.50.1 and reproduced the failures on #25 
- Implemented the fixes as discussed in [this](https://github.com/vatesfr/xen-orchestra/issues/4664#issuecomment-555539099) comment
- Ran `make testacc` and saw that it passed.

![Screenshot from 2019-11-19 17-53-58](https://user-images.githubusercontent.com/5855593/69202179-aa617380-0af5-11ea-89cb-343402e56cca.png)

