### PR TITLE
Improve jsonrpc error handling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -85,6 +85,17 @@ func NewClient(config Config) (*Client, error) {
 	}, nil
 }
 
+func (c *Client) Call(ctx context.Context, method string, params, result interface{}, opt ...jsonrpc2.CallOption) error {
+	err := c.rpc.Call(ctx, method, params, &result, opt...)
+
+	if err != nil {
+		rpcErr, _ := err.(*jsonrpc2.Error)
+
+		return errors.New(fmt.Sprintf("%s: %s", err, *rpcErr.Data))
+	}
+	return nil
+}
+
 type XoObject interface {
 	Compare(obj map[string]interface{}) bool
 	New(obj map[string]interface{}) XoObject
@@ -114,7 +125,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		Objects map[string]interface{} `json:"-"`
 	}
 	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
-	err := c.rpc.Call(ctx, "xo.getAllObjects", params, &objsRes.Objects)
+	err := c.Call(ctx, "xo.getAllObjects", params, &objsRes.Objects)
 
 	if err != nil {
 		return obj, err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type jsonRPCFail struct {
+	err error
+}
+
+func (rpc jsonRPCFail) Call(ctx context.Context, method string, params, result interface{}, opt ...jsonrpc2.CallOption) error {
+	return rpc.err
+}
+
+func (rpc jsonRPCFail) Notify(ctx context.Context, method string, params interface{}, opt ...jsonrpc2.CallOption) error {
+	return nil
+}
+
+func (rpc jsonRPCFail) Close() error {
+	return nil
+}
+
+func TestCall(t *testing.T) {
+	var jsonRpcErr string = `{"errors":[{"code":null,"reason":"type","message":"must be string, but is object","property":"@.template"}]}`
+	rpcCode := 10
+	msg := "invalid parameters"
+	var expectedErrMsg string = fmt.Sprintf(`jsonrpc2: code %d message: %s: %s`, rpcCode, msg, jsonRpcErr)
+	var data json.RawMessage = []byte(jsonRpcErr)
+	c := Client{
+		rpc: jsonRPCFail{
+			err: &jsonrpc2.Error{
+				Data:    &data,
+				Code:    int64(rpcCode),
+				Message: msg,
+			},
+		},
+	}
+
+	params := map[string]interface{}{
+		"test": "test",
+	}
+	err := c.Call(context.TODO(), "dummy method", params, nil)
+
+	if err == nil {
+		t.Errorf("Call method should have returned non-nil error")
+	}
+
+	if err.Error() != expectedErrMsg {
+		t.Errorf("Call method should surface property with invalid parameter. Received `%s` but expected `%s`", err, expectedErrMsg)
+	}
+}

--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -21,7 +21,7 @@ func (c *Client) GetCloudConfig(id string) (*CloudConfig, error) {
 	}
 	var getAllResp CloudConfigResponse
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.rpc.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
+	err := c.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
 
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 	}
 	var resp bool
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.rpc.Call(ctx, "cloudConfig.create", params, &resp)
+	err := c.Call(ctx, "cloudConfig.create", params, &resp)
 
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 	// Since the Id isn't returned in the reponse loop over all cloud configs
 	// and find the one we just created
 	var getAllResp CloudConfigResponse
-	err = c.rpc.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
+	err = c.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
 
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (c *Client) DeleteCloudConfig(id string) error {
 	}
 	var resp bool
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.rpc.Call(ctx, "cloudConfig.delete", params, &resp)
+	err := c.Call(ctx, "cloudConfig.delete", params, &resp)
 
 	if err != nil {
 		return err

--- a/client/vm.go
+++ b/client/vm.go
@@ -77,7 +77,7 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig st
 	fmt.Printf("[DEBUG] VM params %#v", params)
 	var vmId string
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Minute)
-	err := c.rpc.Call(ctx, "vm.create", params, &vmId)
+	err := c.Call(ctx, "vm.create", params, &vmId)
 
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (c *Client) DeleteVm(id string) error {
 	}
 	var reply []interface{}
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Minute)
-	err := c.rpc.Call(ctx, "vm.delete", params, &reply)
+	err := c.Call(ctx, "vm.delete", params, &reply)
 
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (c *Client) GetVm(id string) (*Vm, error) {
 	}
 	var objsRes allObjectResponse
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.rpc.Call(ctx, "xo.getAllObjects", params, &objsRes.Objects)
+	err := c.Call(ctx, "xo.getAllObjects", params, &objsRes.Objects)
 
 	if err != nil {
 		return nil, err

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -1,6 +1,7 @@
 package xoa
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
@@ -52,8 +53,8 @@ func dataSourcePoolRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] Found pool with %+v", pool)
 	d.SetId(pool.Id)
 	cpus := map[string]string{
-		"sockets": string(pool.Cpus.Sockets),
-		"cores":   string(pool.Cpus.Cores),
+		"sockets": fmt.Sprintf("%d", pool.Cpus.Sockets),
+		"cores":   fmt.Sprintf("%d", pool.Cpus.Cores),
 	}
 	d.Set("description", pool.Description)
 	err = d.Set("cpus", cpus)


### PR DESCRIPTION
This is to address #42. Please see that issue for context.

## Todo
- [x] Verify that a failed `terraform apply` surfaces what field an `invalid parameter` jsonrpc2 error applies to
```
Error: jsonrpc2: code 10 message: invalid parameters: {"errors":[{"code":null,"reason":"type","message":"must be string, but is object","property":"@.template"}]}

          on /tmp/tf-test597005198/main.tf line 2:
          (source code not available)
```
- [x] `make testacc` passes

Once this PR is merged I will be able to write terraform acceptance tests that validate a user sees this text in an error when a `terraform apply` fails