### PR TITLE
Add VIF data to the terraform statefile on vm resource creation

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -123,6 +123,8 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		xoApiType = "SR"
 	case Template:
 		xoApiType = "VM-template"
+	case VIF:
+		xoApiType = "VIF"
 	default:
 		panic(fmt.Sprintf("XO client does not support type: %T", t))
 	}
@@ -142,6 +144,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 	}
 
 	found := false
+	objs := make([]interface{}, 0)
 	for _, resObj := range objsRes.Objects {
 		v, ok := resObj.(map[string]interface{})
 		if !ok {
@@ -154,14 +157,19 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 
 		if obj.Compare(v) {
 			found = true
-			obj = obj.New(v)
+			objs = append(objs, obj.New(v))
 		}
 	}
 	if !found {
 		return obj, NotFound{Type: xoApiType}
 	}
 
-	return obj, nil
+	if len(objs) == 1 {
+
+		return objs[0], nil
+	}
+
+	return objs, nil
 }
 
 type handler struct{}

--- a/client/client.go
+++ b/client/client.go
@@ -121,6 +121,8 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		xoApiType = "pool"
 	case StorageRepository:
 		xoApiType = "SR"
+	case Vm:
+		xoApiType = "VM"
 	case Template:
 		xoApiType = "VM-template"
 	case VIF:

--- a/client/vif.go
+++ b/client/vif.go
@@ -1,0 +1,48 @@
+package client
+
+type VIF struct {
+	Network    string
+	Device     string
+	MacAddress string
+	VmId       string
+}
+
+func (v VIF) New(obj map[string]interface{}) XoObject {
+	vmId := obj["$VM"].(string)
+	device := obj["device"].(string)
+	networkId := obj["$network"].(string)
+	macAddress := obj["MAC"].(string)
+	return VIF{
+		Device:     device,
+		MacAddress: macAddress,
+		Network:    networkId,
+		VmId:       vmId,
+	}
+}
+
+func (v VIF) Compare(obj map[string]interface{}) bool {
+	vmId := obj["$VM"].(string)
+	if v.VmId != vmId {
+		return false
+	}
+	return true
+}
+
+func (c *Client) GetVIFs(vm *Vm) ([]VIF, error) {
+	obj, err := c.FindFromGetAllObjects(VIF{VmId: vm.Id})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if vif, ok := obj.(VIF); ok {
+		return []VIF{vif}, nil
+	}
+
+	objs := obj.([]interface{})
+	vifs := make([]VIF, len(objs))
+	for _, vif := range objs {
+		vifs = append(vifs, vif.(VIF))
+	}
+	return vifs, nil
+}

--- a/client/vif_test.go
+++ b/client/vif_test.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetVIFs(t *testing.T) {
+
+	c, err := NewClient(GetConfigFromEnv())
+
+	if err != nil {
+		t.Errorf("failed to create client with error: %v", err)
+	}
+
+	vm, err := c.GetVm("d2efe162-35b3-f84f-8a59-6064b6875b61")
+
+	if err != nil {
+		t.Errorf("failed to get VM with error: %v", err)
+	}
+
+	vifs, err := c.GetVIFs(vm)
+
+	fmt.Printf("%+v", vifs)
+}

--- a/client/vif_test.go
+++ b/client/vif_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -22,5 +21,21 @@ func TestGetVIFs(t *testing.T) {
 
 	vifs, err := c.GetVIFs(vm)
 
-	fmt.Printf("%+v", vifs)
+	for _, vif := range vifs {
+		if vif.Device == "" {
+			t.Errorf("expecting `Device` field to be set on VIF")
+		}
+
+		if vif.MacAddress == "" {
+			t.Errorf("expecting `MacAddress` field to be set on VIF")
+		}
+
+		if vif.Network == "" {
+			t.Errorf("expecting `Network` field to be set on VIF")
+		}
+
+		if vif.VmId != vm.Id {
+			t.Errorf("VIF's VmId `%s` should have matched: %v", vif.VmId, vm)
+		}
+	}
 }

--- a/client/vif_test.go
+++ b/client/vif_test.go
@@ -13,7 +13,8 @@ func TestGetVIFs(t *testing.T) {
 		t.Errorf("failed to create client with error: %v", err)
 	}
 
-	vm, err := c.GetVm("d2efe162-35b3-f84f-8a59-6064b6875b61")
+	vmName := "XOA"
+	vm, err := c.GetVm(Vm{NameLabel: vmName})
 
 	if err != nil {
 		t.Errorf("failed to get VM with error: %v", err)

--- a/xoa/internal/testing.go
+++ b/xoa/internal/testing.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+/*
+ * This file contains code that was borrowed from the terraform-provider-aws repo (https://github.com/terraform-providers/terraform-provider-aws).
+ *
+ * It is covered by the Mozilla Public License Version 2.0.
+ *
+ * See https://github.com/terraform-providers/terraform-provider-aws/blob/master/LICENSE for copyright and licensing information.
+ */
+
+const (
+	sentinelIndex = "*"
+)
+
+// instanceState returns the primary instance state for the given
+// resource name in the root module.
+func instanceState(s *terraform.State, name string) (*terraform.InstanceState, error) {
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s in %s", name, ms.Path)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return nil, fmt.Errorf("No primary instance: %s in %s", name, ms.Path)
+	}
+
+	return is, nil
+}
+
+// TestCheckTypeSetElemAttrPair is a TestCheckFunc that verifies a pair of name/key
+// combinations are equal where the first uses the sentinel value to index into a
+// TypeSet.
+//
+// E.g., tfawsresource.TestCheckTypeSetElemAttrPair("aws_autoscaling_group.bar", "availability_zones.*", "data.aws_availability_zones.available", "names.0")
+func TestCheckTypeSetElemAttrPair(nameFirst, keyFirst, nameSecond, keySecond string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		isFirst, err := instanceState(s, nameFirst)
+		if err != nil {
+			return err
+		}
+
+		isSecond, err := instanceState(s, nameSecond)
+		if err != nil {
+			return err
+		}
+
+		vSecond, okSecond := isSecond.Attributes[keySecond]
+		if !okSecond {
+			return fmt.Errorf("%s: Attribute %q not set, cannot be checked against TypeSet", nameSecond, keySecond)
+		}
+
+		return testCheckTypeSetElem(isFirst, keyFirst, vSecond)
+	}
+}
+
+func testCheckTypeSetElem(is *terraform.InstanceState, attr, value string) error {
+	attrParts := strings.Split(attr, ".")
+	if attrParts[len(attrParts)-1] != sentinelIndex {
+		return fmt.Errorf("%q does not end with the special value %q", attr, sentinelIndex)
+	}
+	for stateKey, stateValue := range is.Attributes {
+		if stateValue == value {
+			stateKeyParts := strings.Split(stateKey, ".")
+			if len(stateKeyParts) == len(attrParts) {
+				for i := range attrParts {
+					if attrParts[i] != stateKeyParts[i] && attrParts[i] != sentinelIndex {
+						break
+					}
+					if i == len(attrParts)-1 {
+						return nil
+					}
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("no TypeSet element %q, with value %q in state: %#v", attr, value, is.Attributes)
+}

--- a/xoa/internal/testing.go
+++ b/xoa/internal/testing.go
@@ -9,7 +9,7 @@ import (
 )
 
 /*
- * This file contains code that was borrowed from the terraform-provider-aws repo (https://github.com/terraform-providers/terraform-provider-aws).
+ * This file contains code that was borrowed from the terraform-provider-aws repo (https://github.com/terraform-providers/terraform-provider-aws). It is provided as is (no modifications) less the code that I did not use.
  *
  * It is covered by the Mozilla Public License Version 2.0.
  *

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -255,7 +255,7 @@ func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	vmObj, err := c.GetVm(xoaId)
+	vmObj, err := c.GetVm(client.Vm{Id: xoaId})
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData
 		return nil, err
 	}
 
-	vmObj, err := c.GetVm(xoaId)
+	vmObj, err := c.GetVm(client.Vm{Id: xoaId})
 	if err != nil {
 		return nil, err
 	}

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -21,7 +22,8 @@ func TestAccXenorchestraVm_create(t *testing.T) {
 				Config: testAccVmConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "id")),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_pif.pif", "network")),
 			},
 		},
 	})

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -29,12 +29,10 @@ func TestAccXenorchestraVm_create(t *testing.T) {
 	})
 }
 
-func testAccVm_import(t *testing.T) {
+func TestAccVm_import(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	// TODO: Need to figure out how to get this to make sure all the attrs
-	// are set. Right now it doesn't actually provide much protection
 	checkFn := func(s []*terraform.InstanceState) error {
-		attrs := []string{"id", "name", "template"}
+		attrs := []string{"id", "name_label"}
 		for _, attr := range attrs {
 			_, ok := s[0].Attributes[attr]
 
@@ -53,15 +51,19 @@ func testAccVm_import(t *testing.T) {
 				Config: testAccVmConfig(),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateCheck:  checkFn,
-				ImportStateVerify: true,
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+				// TODO: Need to store all the
+				// schema.Schema structs in the statefile that
+				// currently exist before this will pass.
+				// ImportStateVerify: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name_description", "description"),
-					resource.TestCheckResourceAttr(resourceName, "name_label", "Name")),
+					resource.TestCheckResourceAttr(resourceName, "name_label", "Name"),
+					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_pif.pif", "network")),
 			},
 		},
 	})

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -78,7 +78,7 @@ func testAccCheckXenorchestraVmDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := c.GetVm(rs.Primary.ID)
+		_, err := c.GetVm(client.Vm{Id: rs.Primary.ID})
 
 		if _, ok := err.(client.NotFound); ok {
 			return nil
@@ -147,7 +147,7 @@ func testAccVmExists(resourceName string) resource.TestCheckFunc {
 			return err
 		}
 
-		vm, err := c.GetVm(rs.Primary.ID)
+		vm, err := c.GetVm(client.Vm{Id: rs.Primary.ID})
 
 		if err != nil {
 			return err


### PR DESCRIPTION
## Todo
- [x] `make testacc` passes
- [x] Add test that ensures the network configuration is set in the statefile upon import
- [x] Find way to test `GetVIFs` without hardcoding a vm uuid
- [x] Add assertions to `TestGetVIFs`
- [x] Create github issue for the new `XoObject` pattern and wether it should replace the new Vm retrieval code (more details in #52).

This is the first part of implementing / fixing #50 and #32. Once the network configuration is tracked in terraform state (what this PR accomplishes) we will be able to do updates, deletes, etc to the network configuration.

Next steps will be to make sure `terraform import`ing a VM sets the state correctly and then handling updates and deletes.