### PR TITLE
Add entire 'query' context when a NotFound XO client error is returned

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -163,7 +163,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		}
 	}
 	if !found {
-		return obj, NotFound{Type: xoApiType}
+		return obj, NotFound{Type: xoApiType, Query: obj}
 	}
 
 	fmt.Printf("[DEBUG] Found the following objects from xo.getAllObjects: %+v\n", objs)

--- a/client/errors.go
+++ b/client/errors.go
@@ -3,13 +3,10 @@ package client
 import "fmt"
 
 type NotFound struct {
-	Id   string
-	Type string
+	Query XoObject
+	Type  string
 }
 
 func (e NotFound) Error() string {
-	// TODO: This does not help when we query for a non ID value like name_label
-	// See https://github.com/terra-farm/terraform-provider-xenorchestra/issues/58
-	// for more details.
-	return fmt.Sprintf("Could not find %s with id: %s", e.Type, e.Id)
+	return fmt.Sprintf("Could not find %s with query: %+v", e.Type, e.Query)
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNotFoundErrorMessage(t *testing.T) {
+	vifType := "VIF"
+	vif := VIF{
+		MacAddress: "E8:61:7E:8E:F1:81",
+	}
+	err := NotFound{
+		Query: vif,
+		Type:  vifType,
+	}
+
+	expectedMsg := fmt.Sprintf("Could not find %s with query: %+v", vifType, vif)
+	msg := err.Error()
+
+	if expectedMsg != msg {
+		t.Errorf("NotFound Error() message expected to be '%s' but received '%s'", expectedMsg, msg)
+	}
+}

--- a/client/template_test.go
+++ b/client/template_test.go
@@ -20,9 +20,9 @@ func TestGetTemplate(t *testing.T) {
 			err: nil,
 		},
 		{
-			templateName: "No found",
+			templateName: "Not found",
 			template:     Template{},
-			err:          NotFound{Type: "VM-template"},
+			err:          NotFound{Type: "VM-template", Query: Template{NameLabel: "Not found"}},
 		},
 	}
 


### PR DESCRIPTION
This addresses #58 

## Todo
- [x] `make testacc` passes