### PR TITLE
Allow the cloud config attribute for vm resource to be optional

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -83,7 +83,6 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		"name_label":       name_label,
 		"name_description": name_description,
 		"template":         template,
-		"cloudConfig":      cloudConfig,
 		"coreOs":           false,
 		"cpuCap":           nil,
 		"cpuWeight":        nil,
@@ -91,6 +90,10 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		"memoryMax":        memoryMax,
 		"existingDisks":    existingDisks,
 		"VIFs":             vifs,
+	}
+
+	if cloudConfig != "" {
+		params["cloudConfig"] = cloudConfig
 	}
 
 	if resourceSet != "" {

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -49,7 +49,7 @@ resource "xenorchestra_vm" "bar" {
 * name_label - (Required) The name of VM.
 * name_description - (Optional) The description of the VM.
 * template - (Required) The ID of the VM template to create the new VM from.
-* cloud_config - (Required) The ID of the cloud config to use
+* cloud_config - (Optional) The content of the cloud config to use
 * cpus - (Required) The number of CPUs the VM will have.
 * memory_max - (Required) The amount of memory in bytes the VM will have.
 * high_availabililty - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -84,7 +84,7 @@ func resourceRecord() *schema.Resource {
 			},
 			"cloud_config": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"core_os": &schema.Schema{
 				Type:     schema.TypeBool,


### PR DESCRIPTION
This addresses #13 

## Todo
- [x] `make testacc` passes
- [x] updated the docs