### PR TITLE
Ensure that the XO client does not reuse an already unmarshalled struct

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,7 +161,6 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 
 	found := false
 	t := reflect.TypeOf(obj)
-	value := reflect.New(t)
 	objs := reflect.MakeSlice(reflect.SliceOf(t), 0, 0)
 	for _, resObj := range objsRes.Objects {
 		v, ok := resObj.(map[string]interface{})
@@ -173,6 +172,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		if err != nil {
 			return objs, err
 		}
+		value := reflect.New(t)
 		err = json.Unmarshal(b, value.Interface())
 		if err != nil {
 			return objs, err
@@ -186,7 +186,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		return objs, NotFound{Query: obj}
 	}
 
-	log.Printf("[TRACE] Found the following objects from xo.getAllObjects: %+v\n", objs)
+	log.Printf("[DEBUG] Found the following objects from xo.getAllObjects: %+v\n", objs)
 
 	return objs.Interface(), nil
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -114,11 +114,11 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		return nil, err
 	}
 
-	vm := Vm{
-		Id: vmId,
-	}
-
-	return &vm, nil
+	return c.GetVm(
+		Vm{
+			Id: vmId,
+		},
+	)
 }
 
 func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, rs string, autoPowerOn bool) (*Vm, error) {


### PR DESCRIPTION
This bug was introduced in the v0.6.0 release. The symptom is that terraform plans will be inconsistent between runs of `terraform plan`. One time you will see no changes and other times you will see a diff that your actual infrastructure does not have.

This was caused by the XO client reusing a struct in parsing the JSON returned from the XO api. This allows unset fields of your actual resource to get "mixed" in with fields on an adjacent object in the `xo.getAllObjects` response. Since the majority of the VM fields are required this issue typically manifests as a diff in the terraform plan related to the `resource_set` attribute on a VM resource.

This will need to be cherry-picked to a v0.6.1 release in addition to the latest release (v0.7.1).

## Todo
- [x] `make testacc` passes against xolab (which experienced this issue)
- [x] `make testacc` passes against my local deployment (which did not experience this issue)