### PR TITLE
Ensure that the XO client does not reuse an already unmarshalled struct

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,7 +161,6 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 
 	found := false
 	t := reflect.TypeOf(obj)
-	value := reflect.New(t)
 	objs := reflect.MakeSlice(reflect.SliceOf(t), 0, 0)
 	for _, resObj := range objsRes.Objects {
 		v, ok := resObj.(map[string]interface{})
@@ -173,6 +172,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		if err != nil {
 			return objs, err
 		}
+		value := reflect.New(t)
 		err = json.Unmarshal(b, value.Interface())
 		if err != nil {
 			return objs, err
@@ -186,7 +186,7 @@ func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {
 		return objs, NotFound{Query: obj}
 	}
 
-	log.Printf("[TRACE] Found the following objects from xo.getAllObjects: %+v\n", objs)
+	log.Printf("[DEBUG] Found the following objects from xo.getAllObjects: %+v\n", objs)
 
 	return objs.Interface(), nil
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -111,11 +111,11 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		return nil, err
 	}
 
-	vm := Vm{
-		Id: vmId,
-	}
-
-	return &vm, nil
+	return c.GetVm(
+		Vm{
+			Id: vmId,
+		},
+	)
 }
 
 func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, rs string, autoPowerOn bool) (*Vm, error) {


### PR DESCRIPTION
This is #77 applied to the v0.6.0 release.

## Todo
- [x] `make testacc` passes against xolab.localdomain