### PR TITLE
Ensure that terraform will recreate a VM if it was deleted manually

### DIFF
--- a/client/resource_set.go
+++ b/client/resource_set.go
@@ -28,6 +28,19 @@ type ResourceSetLimit struct {
 	Total     int `json:"total,omitempty"`
 }
 
+func (rs ResourceSet) Compare(obj interface{}) bool {
+	other := obj.(ResourceSet)
+	if other.Id == rs.Id {
+		return true
+	}
+
+	if other.Name == rs.Name {
+		return true
+	}
+
+	return false
+}
+
 func (c Client) GetResourceSets() ([]ResourceSet, error) {
 	return c.makeResourceSetGetAllCall()
 }
@@ -58,19 +71,14 @@ func (c Client) GetResourceSet(rsReq ResourceSet) ([]ResourceSet, error) {
 	rsRv := []ResourceSet{}
 	found := false
 	for _, rs := range resourceSets {
-		if rsReq.Id == rs.Id {
-			found = true
+		if rs.Compare(rsReq) {
 			rsRv = append(rsRv, rs)
-		}
-
-		if rsReq.Name == rs.Name {
 			found = true
-			rsRv = append(rsRv, rs)
 		}
 	}
 
 	if !found {
-		return rsRv, NotFound{}
+		return rsRv, NotFound{Query: rsReq}
 	}
 
 	return rsRv, nil

--- a/xoa/resource_xenorchestra_resource_set.go
+++ b/xoa/resource_xenorchestra_resource_set.go
@@ -114,6 +114,11 @@ func resourceSetRead(d *schema.ResourceData, m interface{}) error {
 	rs, err := c.GetResourceSetById(id)
 	log.Printf("[DEBUG] Found resource set: %+v with error: %v\n", rs, err)
 
+	if _, ok := err.(client.NotFound); ok {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -282,6 +282,12 @@ func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	vm, err := c.GetVm(client.Vm{Id: xoaId})
+
+	if _, ok := err.(client.NotFound); ok {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This addresses #79.

## Todo
- [x] Apply same change to the resource set and cloud config terraform resources.
- New tests fail on master to ensure that the behavior is fixed
  - [x] vm
  - [x] resource set
  - [x] cloud config (already complete)
- [x] `make testacc` passes