### PR TITLE
Fix panics on failed xo connection

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -69,17 +69,16 @@ func NewClient(config Config) (*Client, error) {
 	}
 
 	objStream := websocket.NewObjectStream(ws)
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	var h jsonrpc2.Handler
 	h = &handler{}
-	c := jsonrpc2.NewConn(ctx, objStream, h)
+	c := jsonrpc2.NewConn(context.Background(), objStream, h)
 
 	reqParams := map[string]interface{}{
 		"email":    username,
 		"password": password,
 	}
 	var reply signInResponse
-	err = c.Call(ctx, "session.signInWithPassword", reqParams, &reply)
+	err = c.Call(context.Background(), "session.signInWithPassword", reqParams, &reply)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +87,8 @@ func NewClient(config Config) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) Call(ctx context.Context, method string, params, result interface{}, opt ...jsonrpc2.CallOption) error {
-	err := c.rpc.Call(ctx, method, params, result, opt...)
+func (c *Client) Call(method string, params, result interface{}, opt ...jsonrpc2.CallOption) error {
+	err := c.rpc.Call(context.Background(), method, params, result, opt...)
 	var callRes interface{}
 	t := reflect.TypeOf(result)
 	if t == nil || t.Kind() != reflect.Ptr {
@@ -146,8 +145,7 @@ func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
 			"type": xoApiType,
 		},
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
-	return c.Call(ctx, "xo.getAllObjects", params, response)
+	return c.Call("xo.getAllObjects", params, response)
 }
 
 func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -45,7 +45,7 @@ func TestCall_withJsonRPC2Error(t *testing.T) {
 	params := map[string]interface{}{
 		"test": "test",
 	}
-	err := c.Call(context.TODO(), "dummy method", params, nil)
+	err := c.Call("dummy method", params, nil)
 
 	if err == nil {
 		t.Errorf("Call method should have returned non-nil error")
@@ -73,7 +73,7 @@ func TestCall_withJsonRPC2ErrorWithNilData(t *testing.T) {
 	params := map[string]interface{}{
 		"test": "test",
 	}
-	err := c.Call(context.TODO(), "dummy method", params, nil)
+	err := c.Call("dummy method", params, nil)
 
 	if err == nil {
 		t.Errorf("Call method should have returned non-nil error")
@@ -95,7 +95,7 @@ func TestCall_withNonJsonRPC2Error(t *testing.T) {
 	params := map[string]interface{}{
 		"test": "test",
 	}
-	err := c.Call(context.TODO(), "dummy method", params, nil)
+	err := c.Call("dummy method", params, nil)
 
 	if err == nil {
 		t.Errorf("Call method should have returned non-nil error")

--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -1,10 +1,5 @@
 package client
 
-import (
-	"context"
-	"time"
-)
-
 type CloudConfig struct {
 	Name     string `json:"name"`
 	Template string `json:"template"`
@@ -20,8 +15,7 @@ func (c *Client) GetCloudConfig(id string) (*CloudConfig, error) {
 		"id": id,
 	}
 	var getAllResp CloudConfigResponse
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
+	err := c.Call("cloudConfig.getAll", params, &getAllResp.Result)
 
 	if err != nil {
 		return nil, err
@@ -48,8 +42,7 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 		"template": template,
 	}
 	var resp bool
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.Call(ctx, "cloudConfig.create", params, &resp)
+	err := c.Call("cloudConfig.create", params, &resp)
 
 	if err != nil {
 		return nil, err
@@ -58,7 +51,7 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 	// Since the Id isn't returned in the reponse loop over all cloud configs
 	// and find the one we just created
 	var getAllResp CloudConfigResponse
-	err = c.Call(ctx, "cloudConfig.getAll", params, &getAllResp.Result)
+	err = c.Call("cloudConfig.getAll", params, &getAllResp.Result)
 
 	if err != nil {
 		return nil, err
@@ -78,8 +71,7 @@ func (c *Client) DeleteCloudConfig(id string) error {
 		"id": id,
 	}
 	var resp bool
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.Call(ctx, "cloudConfig.delete", params, &resp)
+	err := c.Call("cloudConfig.delete", params, &resp)
 
 	if err != nil {
 		return err

--- a/client/network.go
+++ b/client/network.go
@@ -1,12 +1,10 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
 	"strings"
-	"time"
 )
 
 type Network struct {
@@ -43,8 +41,7 @@ func (c *Client) CreateNetwork(netReq Network) (*Network, error) {
 		"name": netReq.NameLabel,
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	err := c.Call(ctx, "network.create", params, &id)
+	err := c.Call("network.create", params, &id)
 
 	if err != nil {
 		return nil, err
@@ -85,8 +82,7 @@ func (c *Client) DeleteNetwork(id string) error {
 		"id": id,
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	err := c.Call(ctx, "network.delete", params, &success)
+	err := c.Call("network.delete", params, &success)
 
 	return err
 }

--- a/client/pool.go
+++ b/client/pool.go
@@ -45,8 +45,12 @@ func FindPoolForTests(pool *Pool) {
 		fmt.Println("The XOA_POOL environment variable must be set")
 		os.Exit(-1)
 	}
-	c, _ := NewClient(GetConfigFromEnv())
-	var err error
+	c, err := NewClient(GetConfigFromEnv())
+	if err != nil {
+		fmt.Printf("failed to create client with error: %v", err)
+		os.Exit(-1)
+	}
+
 	pools, err := c.GetPoolByName(poolName)
 
 	if err != nil {

--- a/client/resource_set.go
+++ b/client/resource_set.go
@@ -1,12 +1,10 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
 	"strings"
-	"time"
 )
 
 type ResourceSet struct {
@@ -86,14 +84,13 @@ func (c Client) GetResourceSet(rsReq ResourceSet) ([]ResourceSet, error) {
 
 func (c Client) makeResourceSetGetAllCall() ([]ResourceSet, error) {
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	var res struct {
 		ResourceSets []ResourceSet `json:"-"`
 	}
 	params := map[string]interface{}{
 		"id": "dummy",
 	}
-	err := c.Call(ctx, "resourceSet.getAll", params, &res.ResourceSets)
+	err := c.Call("resourceSet.getAll", params, &res.ResourceSets)
 	log.Printf("[DEBUG] Calling resourceSet.getAll received response: %+v with error: %v\n", res, err)
 
 	if err != nil {
@@ -119,7 +116,6 @@ func createLimitsMap(rsl ResourceSetLimits) map[string]interface{} {
 }
 
 func (c Client) CreateResourceSet(rsReq ResourceSet) (*ResourceSet, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	rs := ResourceSet{}
 	limits := createLimitsMap(rsReq.Limits)
 	params := map[string]interface{}{
@@ -128,7 +124,7 @@ func (c Client) CreateResourceSet(rsReq ResourceSet) (*ResourceSet, error) {
 		"objects":  rsReq.Objects,
 		"limits":   limits,
 	}
-	err := c.Call(ctx, "resourceSet.create", params, &rs)
+	err := c.Call("resourceSet.create", params, &rs)
 	log.Printf("[DEBUG] Calling resourceSet.create with params: %v returned: %+v with error: %v\n", params, rs, err)
 
 	if err != nil {
@@ -154,86 +150,79 @@ func (c Client) DeleteResourceSet(rsReq ResourceSet) error {
 
 		id = rs[0].Id
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	var success bool
 	params := map[string]interface{}{
 		"id": id,
 	}
-	err := c.Call(ctx, "resourceSet.delete", params, &success)
+	err := c.Call("resourceSet.delete", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.delete call successful: %t with error: %v\n", success, err)
 
 	return err
 }
 
 func (c Client) RemoveResourceSetSubject(rsReq ResourceSet, subject string) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":      rsReq.Id,
 		"subject": subject,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.removeSubject", params, &success)
+	err := c.Call("resourceSet.removeSubject", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.removeSubject call successful: %t with error: %v\n", success, err)
 	return err
 }
 
 func (c Client) AddResourceSetSubject(rsReq ResourceSet, subject string) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":      rsReq.Id,
 		"subject": subject,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.addSubject", params, &success)
+	err := c.Call("resourceSet.addSubject", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.addSubject call successful: %t with error: %v\n", success, err)
 	return err
 }
 
 func (c Client) RemoveResourceSetObject(rsReq ResourceSet, object string) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":     rsReq.Id,
 		"object": object,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.removeObject", params, &success)
+	err := c.Call("resourceSet.removeObject", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.removeObject call successful: %t with error: %v\n", success, err)
 	return err
 }
 
 func (c Client) AddResourceSetObject(rsReq ResourceSet, object string) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":     rsReq.Id,
 		"object": object,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.addObject", params, &success)
+	err := c.Call("resourceSet.addObject", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.addObject call successful: %t with error: %v\n", success, err)
 	return err
 }
 
 func (c Client) RemoveResourceSetLimit(rsReq ResourceSet, limit string) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":      rsReq.Id,
 		"limitId": limit,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.removeLimit", params, &success)
+	err := c.Call("resourceSet.removeLimit", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.removeLimit call successful: %t with error: %v\n", success, err)
 	return err
 }
 
 func (c Client) AddResourceSetLimit(rsReq ResourceSet, limit string, quantity int) error {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	params := map[string]interface{}{
 		"id":       rsReq.Id,
 		"limitId":  limit,
 		"quantity": quantity,
 	}
 	var success bool
-	err := c.Call(ctx, "resourceSet.addLimit", params, &success)
+	err := c.Call("resourceSet.addLimit", params, &success)
 	log.Printf("[DEBUG] Calling resourceSet.addLimit call with params: %v successful: %t with error: %v\n", params, success, err)
 	return err
 }

--- a/client/storage_repository.go
+++ b/client/storage_repository.go
@@ -89,8 +89,12 @@ func (c *Client) GetStorageRepository(sr StorageRepository) ([]StorageRepository
 }
 
 func FindStorageRepositoryForTests(pool Pool, sr *StorageRepository, tag string) {
-	c, _ := NewClient(GetConfigFromEnv())
-	var err error
+	c, err := NewClient(GetConfigFromEnv())
+	if err != nil {
+		fmt.Printf("failed to create client with error: %v", err)
+		os.Exit(-1)
+	}
+
 	defaultSr, err := c.GetStorageRepositoryById(pool.DefaultSR)
 
 	if err != nil {

--- a/client/tag.go
+++ b/client/tag.go
@@ -1,11 +1,9 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
-	"time"
 )
 
 func (c *Client) AddTag(id, tag string) error {
@@ -14,8 +12,7 @@ func (c *Client) AddTag(id, tag string) error {
 		"id":  id,
 		"tag": tag,
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	err := c.Call(ctx, "tag.add", params, &success)
+	err := c.Call("tag.add", params, &success)
 
 	if err != nil {
 		return err
@@ -29,8 +26,7 @@ func (c *Client) RemoveTag(id, tag string) error {
 		"id":  id,
 		"tag": tag,
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	err := c.Call(ctx, "tag.remove", params, &success)
+	err := c.Call("tag.remove", params, &success)
 
 	if err != nil {
 		return err
@@ -47,8 +43,7 @@ func (c *Client) GetObjectsWithTags(tags []string) ([]string, error) {
 			"tags": tags,
 		},
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
-	c.Call(ctx, "xo.getAllObjects", params, &objsRes.Objects)
+	c.Call("xo.getAllObjects", params, &objsRes.Objects)
 	log.Printf("[DEBUG] Found objects with tags `%s`: %v\n", tags, objsRes)
 
 	t := []string{}

--- a/client/vif.go
+++ b/client/vif.go
@@ -1,11 +1,9 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
-	"time"
 )
 
 type VIF struct {
@@ -73,8 +71,7 @@ func (c *Client) CreateVIF(vm *Vm, vif *VIF) (*VIF, error) {
 		"network": vif.Network,
 		"vm":      vm.Id,
 	}
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-	err := c.Call(ctx, "vm.createInterface", params, &id)
+	err := c.Call("vm.createInterface", params, &id)
 
 	if err != nil {
 		return nil, err
@@ -102,15 +99,14 @@ func (c *Client) DeleteVIF(vifReq *VIF) (err error) {
 		"id": vif.Id,
 	}
 	var result bool
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
-	err = c.Call(ctx, "vif.disconnect", params, &result)
+	err = c.Call("vif.disconnect", params, &result)
 	log.Printf("[DEBUG] Calling vif.disconnect received err: %v", err)
 
 	if err != nil {
 		return err
 	}
 
-	err = c.Call(ctx, "vif.delete", params, &result)
+	err = c.Call("vif.delete", params, &result)
 	log.Printf("[DEBUG] Calling vif.delete received err: %v", err)
 
 	if err != nil {

--- a/client/vm.go
+++ b/client/vm.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -101,8 +100,7 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 	}
 	log.Printf("[DEBUG] VM params for vm.create %#v", params)
 	var vmId string
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Minute)
-	err := c.Call(ctx, "vm.create", params, &vmId)
+	err := c.Call("vm.create", params, &vmId)
 
 	if err != nil {
 		return nil, err
@@ -141,9 +139,8 @@ func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, r
 		// pv_args, cpuMask cpuWeight cpuCap affinityHost vga videoram coresPerSocket hasVendorDevice expNestedHvm resourceSet share startDelay nicType hvmBootFirmware virtualizationMode
 	}
 	log.Printf("[DEBUG] VM params for vm.set: %#v", params)
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Minute)
 	var success bool
-	err := c.Call(ctx, "vm.set", params, &success)
+	err := c.Call("vm.set", params, &success)
 
 	if err != nil {
 		return nil, err
@@ -161,8 +158,7 @@ func (c *Client) DeleteVm(id string) error {
 		"id": id,
 	}
 	var reply []interface{}
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Minute)
-	err := c.Call(ctx, "vm.delete", params, &reply)
+	err := c.Call("vm.delete", params, &reply)
 
 	if err != nil {
 		return err

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -64,6 +65,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -110,6 +112,7 @@ github.com/hashicorp/hcl/v2 v2.0.0 h1:efQznTz+ydmQXq3BOnRa3AXzvCeTq1P4dKj/z5GLlY
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8 h1:+RyjwU+Gnd/aTJBPZVDNm903eXVjjqhbaR4Ypx3xYyY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-exec v0.1.1 h1:soHqDz5365aZVt9pyTT7ArOXSpMqaHGMYq4VhI+HNkE=
 github.com/hashicorp/terraform-exec v0.1.1/go.mod h1:yKWvMPtkTaHpeAmllw+1qdHZ7E5u+pAZ+x8e2jQF6gM=
@@ -119,6 +122,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.15.0 h1:bmYnTT7MqNXlUHDc7pT8E6uKT2g
 github.com/hashicorp/terraform-plugin-sdk v1.15.0/go.mod h1:PuFTln8urDmRM6mV0II6apOTsyG/iHkxp+5W11eJE58=
 github.com/hashicorp/terraform-plugin-test v1.4.3 h1:HSOZZu2W7a9tx4QPYXhrT9oh7JptibaSkP7CK4C0OF0=
 github.com/hashicorp/terraform-plugin-test v1.4.3/go.mod h1:UA7z/02pgqsRLut4DJIPm0Hjnj27uOvhi19c8kTqIfM=
+github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
@@ -194,10 +198,12 @@ github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
+github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty-yaml v1.0.1 h1:up11wlgAaDvlAGENcFDnZgkn0qUJurso7k6EpURKNF8=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
@@ -231,6 +237,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -254,6 +261,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -291,6 +299,7 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200310143817-43be25429f5a h1:lRlI5zu6AFy3iU/F8YWyNrAmn/tPCnhiTxfwhWb76eU=
 google.golang.org/genproto v0.0.0-20200310143817-43be25429f5a/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -299,6 +308,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -31,7 +31,7 @@ func dataSourceXoaPool() *schema.Resource {
 }
 
 func dataSourcePoolRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -31,12 +31,7 @@ func dataSourceXoaPool() *schema.Resource {
 }
 
 func dataSourcePoolRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 

--- a/xoa/data_source_resource_set.go
+++ b/xoa/data_source_resource_set.go
@@ -21,12 +21,7 @@ func dataSourceXoaResourceSet() *schema.Resource {
 }
 
 func dataSourceResourceSetRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	name := d.Get("name").(string)
 

--- a/xoa/data_source_resource_set.go
+++ b/xoa/data_source_resource_set.go
@@ -21,7 +21,7 @@ func dataSourceXoaResourceSet() *schema.Resource {
 }
 
 func dataSourceResourceSetRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	name := d.Get("name").(string)
 

--- a/xoa/data_source_xenorchestra_network.go
+++ b/xoa/data_source_xenorchestra_network.go
@@ -27,7 +27,7 @@ func dataSourceXoaNetwork() *schema.Resource {
 }
 
 func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/data_source_xenorchestra_network.go
+++ b/xoa/data_source_xenorchestra_network.go
@@ -27,8 +27,7 @@ func dataSourceXoaNetwork() *schema.Resource {
 }
 
 func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
+	c := m.(client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/data_source_xenorchestra_pif.go
+++ b/xoa/data_source_xenorchestra_pif.go
@@ -50,12 +50,7 @@ func dataSourceXoaPIF() *schema.Resource {
 }
 
 func dataSourcePIFRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	device := d.Get("device").(string)
 	vlan := d.Get("vlan").(int)

--- a/xoa/data_source_xenorchestra_pif.go
+++ b/xoa/data_source_xenorchestra_pif.go
@@ -50,7 +50,7 @@ func dataSourceXoaPIF() *schema.Resource {
 }
 
 func dataSourcePIFRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	device := d.Get("device").(string)
 	vlan := d.Get("vlan").(int)

--- a/xoa/data_source_xenorchestra_sr.go
+++ b/xoa/data_source_xenorchestra_sr.go
@@ -40,7 +40,7 @@ func dataSourceXoaStorageRepository() *schema.Resource {
 }
 
 func dataSourceStorageRepositoryRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/data_source_xenorchestra_sr.go
+++ b/xoa/data_source_xenorchestra_sr.go
@@ -40,12 +40,7 @@ func dataSourceXoaStorageRepository() *schema.Resource {
 }
 
 func dataSourceStorageRepositoryRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/data_source_xenorchestra_template.go
+++ b/xoa/data_source_xenorchestra_template.go
@@ -29,7 +29,7 @@ func dataSourceXoaTemplate() *schema.Resource {
 }
 
 func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/data_source_xenorchestra_template.go
+++ b/xoa/data_source_xenorchestra_template.go
@@ -29,12 +29,7 @@ func dataSourceXoaTemplate() *schema.Resource {
 }
 
 func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	poolId := d.Get("pool_id").(string)

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -45,14 +45,14 @@ func Provider() terraform.ResourceProvider {
 	}
 }
 
-func xoaConfigure(d *schema.ResourceData) (c interface{}, err error) {
+func xoaConfigure(d *schema.ResourceData) (interface{}, error) {
 	url := d.Get("url").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
-	c = client.Config{
+	config := client.Config{
 		Url:      url,
 		Username: username,
 		Password: password,
 	}
-	return c, nil
+	return client.NewClient(config)
 }

--- a/xoa/resource_xenorchestra_cloud_config.go
+++ b/xoa/resource_xenorchestra_cloud_config.go
@@ -30,7 +30,7 @@ func resourceCloudConfigRecord() *schema.Resource {
 }
 
 func resourceCloudConfigCreate(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	cloud_config, err := c.CreateCloudConfig(d.Get("name").(string), d.Get("template").(string))
 	if err != nil {
@@ -41,7 +41,7 @@ func resourceCloudConfigCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	cloud_config, err := c.GetCloudConfig(d.Id())
 	if err != nil {
@@ -59,7 +59,7 @@ func resourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	err := c.DeleteCloudConfig(d.Id())
 
@@ -72,7 +72,7 @@ func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
 
 func CloudConfigImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	cloud_config, err := c.GetCloudConfig(d.Id())
 

--- a/xoa/resource_xenorchestra_cloud_config.go
+++ b/xoa/resource_xenorchestra_cloud_config.go
@@ -30,11 +30,7 @@ func resourceCloudConfigRecord() *schema.Resource {
 }
 
 func resourceCloudConfigCreate(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	cloud_config, err := c.CreateCloudConfig(d.Get("name").(string), d.Get("template").(string))
 	if err != nil {
@@ -45,11 +41,7 @@ func resourceCloudConfigCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	cloud_config, err := c.GetCloudConfig(d.Id())
 	if err != nil {
@@ -67,13 +59,9 @@ func resourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
-	err = c.DeleteCloudConfig(d.Id())
+	err := c.DeleteCloudConfig(d.Id())
 
 	if err != nil {
 		return err
@@ -84,11 +72,7 @@ func resourceCloudConfigDelete(d *schema.ResourceData, m interface{}) error {
 
 func CloudConfigImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-	if err != nil {
-		return nil, err
-	}
+	c := m.(client.Client)
 
 	cloud_config, err := c.GetCloudConfig(d.Id())
 

--- a/xoa/resource_xenorchestra_resource_set.go
+++ b/xoa/resource_xenorchestra_resource_set.go
@@ -59,12 +59,7 @@ func resourceResourceSet() *schema.Resource {
 }
 
 func resourceSetCreate(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	name := d.Get("name").(string)
 	limits := d.Get("limit").(*schema.Set)
@@ -103,12 +98,7 @@ func resourceSetCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetRead(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	id := d.Id()
 	rs, err := c.GetResourceSetById(id)
@@ -127,8 +117,7 @@ func resourceSetRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetUpdate(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
+	c := m.(client.Client)
 
 	id := d.Id()
 	rs, err := c.GetResourceSetById(id)
@@ -226,14 +215,9 @@ func resourceSetUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetDelete(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
+	c := m.(client.Client)
 
-	if err != nil {
-		return err
-	}
-
-	err = c.DeleteResourceSet(client.ResourceSet{Id: d.Id()})
+	err := c.DeleteResourceSet(client.ResourceSet{Id: d.Id()})
 
 	if err != nil {
 		return err

--- a/xoa/resource_xenorchestra_resource_set.go
+++ b/xoa/resource_xenorchestra_resource_set.go
@@ -59,7 +59,7 @@ func resourceResourceSet() *schema.Resource {
 }
 
 func resourceSetCreate(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	name := d.Get("name").(string)
 	limits := d.Get("limit").(*schema.Set)
@@ -98,7 +98,7 @@ func resourceSetCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	id := d.Id()
 	rs, err := c.GetResourceSetById(id)
@@ -117,7 +117,7 @@ func resourceSetRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetUpdate(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	id := d.Id()
 	rs, err := c.GetResourceSetById(id)
@@ -215,7 +215,7 @@ func resourceSetUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSetDelete(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	err := c.DeleteResourceSet(client.ResourceSet{Id: d.Id()})
 

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -190,12 +190,7 @@ func resourceRecord() *schema.Resource {
 }
 
 func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	network_maps := []map[string]string{}
 	networks := d.Get("network").(*schema.Set)
@@ -274,14 +269,9 @@ func vifsToMapList(vifs []client.VIF) []map[string]interface{} {
 }
 
 func resourceVmRead(d *schema.ResourceData, m interface{}) error {
-	xoaId := d.Id()
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
+	c := m.(client.Client)
 
-	if err != nil {
-		return err
-	}
-	vm, err := c.GetVm(client.Vm{Id: xoaId})
+	vm, err := c.GetVm(client.Vm{Id: d.Id()})
 
 	if _, ok := err.(client.NotFound); ok {
 		d.SetId("")
@@ -302,12 +292,7 @@ func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return err
-	}
+	c := m.(client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	nameDescription := d.Get("name_description").(string)
@@ -358,14 +343,9 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
+	c := m.(client.Client)
 
-	if err != nil {
-		return err
-	}
-
-	err = c.DeleteVm(d.Id())
+	err := c.DeleteVm(d.Id())
 
 	if err != nil {
 		return err
@@ -394,16 +374,9 @@ func expandNetworks(networks []interface{}) []*client.VIF {
 }
 
 func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	xoaId := d.Id()
+	c := m.(client.Client)
 
-	config := m.(client.Config)
-	c, err := client.NewClient(config)
-
-	if err != nil {
-		return nil, err
-	}
-
-	vm, err := c.GetVm(client.Vm{Id: xoaId})
+	vm, err := c.GetVm(client.Vm{Id: d.Id()})
 	if err != nil {
 		return nil, err
 	}

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -190,7 +190,7 @@ func resourceRecord() *schema.Resource {
 }
 
 func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	network_maps := []map[string]string{}
 	networks := d.Get("network").(*schema.Set)
@@ -269,7 +269,7 @@ func vifsToMapList(vifs []client.VIF) []map[string]interface{} {
 }
 
 func resourceVmRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	vm, err := c.GetVm(client.Vm{Id: d.Id()})
 
@@ -292,7 +292,7 @@ func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	nameLabel := d.Get("name_label").(string)
 	nameDescription := d.Get("name_description").(string)
@@ -343,7 +343,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	err := c.DeleteVm(d.Id())
 
@@ -374,7 +374,7 @@ func expandNetworks(networks []interface{}) []*client.VIF {
 }
 
 func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	c := m.(client.Client)
+	c := m.(*client.Client)
 
 	vm, err := c.GetVm(client.Vm{Id: d.Id()})
 	if err != nil {


### PR DESCRIPTION
This addresses #81. This PR fixes the issue by pushing the creation of the XO api connection inside the terraform provider initialization. This means that all resources and data sources will have consistent error handling in the face of connection issues. There was also  code outside of the terraform provider (client package) that was ignoring errors so I added the proper error handling there as well.

## Todo
- [x] `make testacc` passes