### PR TITLE
Implement disk additions, removals and disk updates (connect, disconnect)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: import testacc dist
 
-
+TIMEOUT ?= 40m
 ifdef TEST
     TEST := ./... -run $(TEST)
 else
@@ -28,4 +28,4 @@ apply:
 	terraform apply
 
 testacc:
-	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout 40m
+	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)

--- a/client/client.go
+++ b/client/client.go
@@ -137,6 +137,10 @@ func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
 		xoApiType = "VM-template"
 	case VIF:
 		xoApiType = "VIF"
+	case VBD:
+		xoApiType = "VBD"
+	case VDI:
+		xoApiType = "VDI"
 	default:
 		panic(fmt.Sprintf("XO client does not support type: %T", t))
 	}

--- a/client/network.go
+++ b/client/network.go
@@ -59,7 +59,7 @@ func (c *Client) GetNetwork(netReq Network) (*Network, error) {
 	nets := obj.([]Network)
 
 	if len(nets) > 1 {
-		return nil, errors.New(fmt.Sprintf("Your query returned more than one result: %+v. Use `pool_id` or other fieldss to filter the result down to a single network", nets))
+		return nil, errors.New(fmt.Sprintf("Your query returned more than one result: %+v. Use `pool_id` or other fields to filter the result down to a single network", nets))
 	}
 
 	return &nets[0], nil

--- a/client/network.go
+++ b/client/network.go
@@ -59,7 +59,7 @@ func (c *Client) GetNetwork(netReq Network) (*Network, error) {
 	nets := obj.([]Network)
 
 	if len(nets) > 1 {
-		return nil, errors.New(fmt.Sprintf("Your query returned more than one result: %+v. Use `pool_id` or other attributes to filter the result down to a single network", nets))
+		return nil, errors.New(fmt.Sprintf("Your query returned more than one result: %+v. Use `pool_id` or other fieldss to filter the result down to a single network", nets))
 	}
 
 	return &nets[0], nil

--- a/client/network.go
+++ b/client/network.go
@@ -59,7 +59,7 @@ func (c *Client) GetNetwork(netReq Network) (*Network, error) {
 	nets := obj.([]Network)
 
 	if len(nets) > 1 {
-		return nil, errors.New("Your query returned more than one result. Use `pool_id` or other attributes to filter the result down to a single network")
+		return nil, errors.New(fmt.Sprintf("Your query returned more than one result: %+v. Use `pool_id` or other attributes to filter the result down to a single network", nets))
 	}
 
 	return &nets[0], nil

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -34,10 +34,12 @@ var integrationTestPrefix string = "xenorchestra-client-"
 var accTestPool Pool
 var accDefaultSr StorageRepository
 var testTemplateName string
+var accVm Vm
 
 func TestMain(m *testing.M) {
 	FindPoolForTests(&accTestPool)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
+	FindVmForTests(&accVm, integrationTestPrefix)
 	CreateNetwork()
 	CreateResourceSet(testResourceSet)
 

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -16,39 +15,40 @@ func CreateResourceSet(rs ResourceSet) error {
 	return err
 }
 
-func CreateNetwork() error {
+func CreateNetwork(network *Network) error {
 	c, err := NewClient(GetConfigFromEnv())
 
 	if err != nil {
 		return err
 	}
 
-	_, err = c.CreateNetwork(Network{
+	net, err := c.CreateNetwork(Network{
 		NameLabel: testNetworkName,
 		PoolId:    accTestPool.Id,
 	})
-	return err
+
+	if err != nil {
+		return err
+	}
+	*network = *net
+	return nil
 }
 
 var integrationTestPrefix string = "xenorchestra-client-"
 var accTestPool Pool
 var accDefaultSr StorageRepository
-var testTemplateName string
+var accDefaultNetwork Network
+var testTemplate Template
 var accVm Vm
 
 func TestMain(m *testing.M) {
+
+	FindTemplateForTests(&testTemplate)
 	FindPoolForTests(&accTestPool)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
-	FindVmForTests(&accVm, integrationTestPrefix)
-	CreateNetwork()
+	CreateNetwork(&accDefaultNetwork)
+	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, accDefaultNetwork.Id, testTemplate.Id, integrationTestPrefix)
 	CreateResourceSet(testResourceSet)
-
-	var found bool
-	testTemplateName, found = os.LookupEnv("XOA_TEMPLATE")
-	if !found {
-		fmt.Println("The XOA_TEMPLATE environment variable must be set for the tests")
-		os.Exit(-1)
-	}
 
 	code := m.Run()
 

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -32,10 +32,12 @@ func CreateNetwork() error {
 
 var integrationTestPrefix string = "xenorchestra-client-"
 var accTestPool Pool
+var accDefaultSr StorageRepository
 var testTemplateName string
 
 func TestMain(m *testing.M) {
 	FindPoolForTests(&accTestPool)
+	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
 	CreateNetwork()
 	CreateResourceSet(testResourceSet)
 

--- a/client/tag.go
+++ b/client/tag.go
@@ -34,7 +34,12 @@ func (c *Client) RemoveTag(id, tag string) error {
 	return nil
 }
 
-func (c *Client) GetObjectsWithTags(tags []string) ([]string, error) {
+type Object struct {
+	Id   string
+	Type string
+}
+
+func (c *Client) GetObjectsWithTags(tags []string) ([]Object, error) {
 	var objsRes struct {
 		Objects map[string]interface{} `json:"-"`
 	}
@@ -46,7 +51,7 @@ func (c *Client) GetObjectsWithTags(tags []string) ([]string, error) {
 	c.Call("xo.getAllObjects", params, &objsRes.Objects)
 	log.Printf("[DEBUG] Found objects with tags `%s`: %v\n", tags, objsRes)
 
-	t := []string{}
+	t := []Object{}
 	for _, resObject := range objsRes.Objects {
 		obj, ok := resObject.(map[string]interface{})
 
@@ -55,7 +60,11 @@ func (c *Client) GetObjectsWithTags(tags []string) ([]string, error) {
 		}
 
 		id := obj["id"].(string)
-		t = append(t, id)
+		objType := obj["type"].(string)
+		t = append(t, Object{
+			Id:   id,
+			Type: objType,
+		})
 	}
 	return t, nil
 }
@@ -75,7 +84,7 @@ func RemoveTagFromAllObjects(tag string) func(string) error {
 
 		for _, object := range objects {
 			log.Printf("[DEBUG] Remove tag `%s` on object `%s`\n", tag, object)
-			err = c.RemoveTag(object, tag)
+			err = c.RemoveTag(object.Id, tag)
 
 			if err != nil {
 				log.Printf("error remove tag `%s` during sweep: %v", tag, err)

--- a/client/template.go
+++ b/client/template.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"os"
 )
 
 type Template struct {
@@ -41,4 +43,35 @@ func (c *Client) GetTemplate(template Template) ([]Template, error) {
 	}
 
 	return templates, nil
+}
+
+func FindTemplateForTests(template *Template) {
+	var found bool
+	templateName, found := os.LookupEnv("XOA_TEMPLATE")
+	if !found {
+		fmt.Println("The XOA_TEMPLATE environment variable must be set for the tests")
+		os.Exit(-1)
+	}
+
+	c, err := NewClient(GetConfigFromEnv())
+	if err != nil {
+		fmt.Printf("failed to create client with error: %v", err)
+		os.Exit(-1)
+	}
+
+	templates, err := c.GetTemplate(Template{
+		NameLabel: templateName,
+	})
+
+	if err != nil {
+		fmt.Printf("failed to find templates with error: %v\n", err)
+		os.Exit(-1)
+	}
+
+	l := len(templates)
+	if l != 1 {
+		fmt.Printf("found %d templates when expected to find 1. templates found: %v\n", l, templates)
+		os.Exit(-1)
+	}
+	*template = templates[0]
 }

--- a/client/template_test.go
+++ b/client/template_test.go
@@ -11,9 +11,9 @@ func TestGetTemplate(t *testing.T) {
 		err          error
 	}{
 		{
-			templateName: testTemplateName,
+			templateName: testTemplate.NameLabel,
 			template: Template{
-				NameLabel: testTemplateName,
+				NameLabel: testTemplate.NameLabel,
 			},
 			err: nil,
 		},

--- a/client/vdi.go
+++ b/client/vdi.go
@@ -71,7 +71,6 @@ func (c *Client) GetDisks(vm *Vm) ([]Disk, error) {
 		return []Disk{}, errors.New(fmt.Sprintf("failed to coerce %v into VBD", obj))
 	}
 
-	fmt.Printf("Found the following disks before looking for VDIs %+v", disks)
 	vdis := []Disk{}
 	for _, disk := range disks {
 		vdi, err := c.GetParentVDI(disk)
@@ -90,8 +89,9 @@ func (c *Client) GetParentVDI(vbd VBD) (VDI, error) {
 		VDIId: vbd.VDI,
 	})
 
-	// Rather than detect not found errors we let the caller
-	// decide that for themselves.
+	// Rather than detect not found errors for finding the
+	// parent VDI this is considered an error so we return
+	// it to the caller.
 	if err != nil {
 		return VDI{}, err
 	}
@@ -130,15 +130,6 @@ func (c *Client) DeleteDisk(vm Vm, d Disk) error {
 	if err != nil {
 		return err
 	}
-
-	// deleteParams := map[string]interface{}{
-	// 	"id": d.Id,
-	// }
-	// err = c.Call("vbd.delete", deleteParams, &success)
-
-	// if err != nil {
-	// 	return err
-	// }
 
 	vdiDeleteParams := map[string]interface{}{
 		"id": d.VDIId,

--- a/client/vdi.go
+++ b/client/vdi.go
@@ -131,17 +131,33 @@ func (c *Client) DeleteDisk(vm Vm, d Disk) error {
 		return err
 	}
 
-	deleteParams := map[string]interface{}{
-		"id": d.Id,
-	}
-	err = c.Call("vbd.delete", deleteParams, &success)
+	// deleteParams := map[string]interface{}{
+	// 	"id": d.Id,
+	// }
+	// err = c.Call("vbd.delete", deleteParams, &success)
 
-	if err != nil {
-		return err
-	}
+	// if err != nil {
+	// 	return err
+	// }
 
 	vdiDeleteParams := map[string]interface{}{
 		"id": d.VDIId,
 	}
 	return c.Call("vdi.delete", vdiDeleteParams, &success)
+}
+
+func (c *Client) ConnectDisk(d Disk) error {
+	var success bool
+	params := map[string]interface{}{
+		"id": d.Id,
+	}
+	return c.Call("vbd.connect", params, &success)
+}
+
+func (c *Client) DisconnectDisk(d Disk) error {
+	var success bool
+	params := map[string]interface{}{
+		"id": d.Id,
+	}
+	return c.Call("vbd.disconnect", params, &success)
 }

--- a/client/vdi.go
+++ b/client/vdi.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Disk struct {
+	VBD
+	VDI
+}
+
+type VDI struct {
+	VDIId     string   `json:"id"`
+	SrId      string   `json:"$SR"`
+	NameLabel string   `json:"name_label"`
+	Size      int      `json:"size"`
+	VBDs      []string `json:"$VBDs"`
+}
+
+func (v VDI) Compare(obj interface{}) bool {
+	other := obj.(VDI)
+
+	if v.VDIId != "" && other.VDIId == v.VDIId {
+		return true
+	}
+
+	return false
+}
+
+// TODO: Change this file to storage or disks?
+type VBD struct {
+	Id        string `json:"id"`
+	Attached  bool
+	Device    string
+	ReadOnly  bool   `json:"read_only"`
+	VmId      string `json:"VM"`
+	VDI       string `json:"VDI"`
+	IsCdDrive bool   `json:"is_cd_drive"`
+	Position  string
+	Bootable  bool
+	PoolId    string `json:"$poolId"`
+}
+
+func (v VBD) Compare(obj interface{}) bool {
+	other := obj.(VBD)
+	if v.IsCdDrive != other.IsCdDrive {
+		return false
+	}
+
+	if other.VmId != "" && v.VmId == other.VmId {
+		return true
+	}
+
+	return false
+}
+
+func (c *Client) GetDisks(vm *Vm) ([]Disk, error) {
+	obj, err := c.FindFromGetAllObjects(VBD{VmId: vm.Id, IsCdDrive: false})
+
+	if _, ok := err.(NotFound); ok {
+		return []Disk{}, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	disks, ok := obj.([]VBD)
+
+	if !ok {
+		return []Disk{}, errors.New(fmt.Sprintf("failed to coerce %v into VBD", obj))
+	}
+
+	fmt.Printf("Found the following disks before looking for VDIs %+v", disks)
+	vdis := []Disk{}
+	for _, disk := range disks {
+		vdi, err := c.GetParentVDI(disk)
+
+		if err != nil {
+			return []Disk{}, err
+		}
+
+		vdis = append(vdis, Disk{disk, vdi})
+	}
+	return vdis, nil
+}
+
+func (c *Client) GetParentVDI(vbd VBD) (VDI, error) {
+	obj, err := c.FindFromGetAllObjects(VDI{
+		VDIId: vbd.VDI,
+	})
+
+	// Rather than detect not found errors we let the caller
+	// decide that for themselves.
+	if err != nil {
+		return VDI{}, err
+	}
+	disks, ok := obj.([]VDI)
+
+	if !ok {
+		return VDI{}, errors.New(fmt.Sprintf("failed to coerce %+v into VDI", obj))
+	}
+
+	if len(disks) != 1 {
+		return VDI{}, errors.New(fmt.Sprintf("expected Vm VDI to only contain a single VBD, instead found %d", len(disks)))
+	}
+	return disks[0], nil
+}
+
+func (c *Client) CreateDisk(vm Vm, d Disk) (string, error) {
+	var id string
+	params := map[string]interface{}{
+		"name": d.NameLabel,
+		"size": d.Size,
+		"sr":   d.SrId,
+		"vm":   vm.Id,
+	}
+	err := c.Call("disk.create", params, &id)
+
+	return id, err
+}
+
+func (c *Client) DeleteDisk(vm Vm, d Disk) error {
+	var success bool
+	disconnectParams := map[string]interface{}{
+		"id": d.Id,
+	}
+	err := c.Call("vbd.disconnect", disconnectParams, &success)
+
+	if err != nil {
+		return err
+	}
+
+	deleteParams := map[string]interface{}{
+		"id": d.Id,
+	}
+	err = c.Call("vbd.delete", deleteParams, &success)
+
+	if err != nil {
+		return err
+	}
+
+	vdiDeleteParams := map[string]interface{}{
+		"id": d.VDIId,
+	}
+	return c.Call("vdi.delete", vdiDeleteParams, &success)
+}

--- a/client/vdi_test.go
+++ b/client/vdi_test.go
@@ -94,3 +94,30 @@ func TestCreateDiskAndDeleteDisk(t *testing.T) {
 		}
 	}
 }
+
+func TestDisconnectDiskAndConnectDisk(t *testing.T) {
+	c, err := NewClient(GetConfigFromEnv())
+
+	if err != nil {
+		t.Fatalf("failed to create client with error: %v", err)
+	}
+
+	// TODO: Create Vm for client tests / optionally allow
+	// for running tests against a running Vm
+	vm := Vm{
+		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
+	}
+	disks, err := c.GetDisks(&vm)
+
+	if err != nil {
+		t.Fatalf("failed to retrieve disks with error: %v", err)
+	}
+
+	if err := c.DisconnectDisk(disks[1]); err != nil {
+		t.Fatalf("failed to disconnect disk: %+v with error: %v", disks[1], err)
+	}
+
+	if err := c.ConnectDisk(disks[1]); err != nil {
+		t.Errorf("failed to connect disk: %+v with error: %v", disks[1], err)
+	}
+}

--- a/client/vdi_test.go
+++ b/client/vdi_test.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetVmDisks(t *testing.T) {
+	c, err := NewClient(GetConfigFromEnv())
+
+	if err != nil {
+		t.Fatalf("failed to create client with error: %v", err)
+	}
+
+	// TODO: Create Vm for client tests / optionally allow
+	// for running tests against a running Vm
+	disks, err := c.GetDisks(&Vm{
+		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
+	})
+
+	if err != nil {
+		t.Fatalf("failed to get disks of VM with error: %v", err)
+	}
+
+	if len(disks) <= 0 {
+		t.Fatalf("failed to find disks for Vm")
+	}
+
+	fmt.Printf("Found disks with %+v", disks)
+	if !validateDisk(disks[0]) {
+		t.Errorf("failed to validate that disks contained expected data")
+	}
+}
+
+func validateDisk(disk Disk) bool {
+	if disk.Id == "" {
+		return false
+	}
+
+	if disk.PoolId == "" {
+		return false
+	}
+
+	if disk.Device == "" {
+		return false
+	}
+
+	if disk.NameLabel == "" {
+		return false
+	}
+	return true
+}
+
+func TestCreateDiskAndDeleteDisk(t *testing.T) {
+	c, err := NewClient(GetConfigFromEnv())
+
+	if err != nil {
+		t.Fatalf("failed to create client with error: %v", err)
+	}
+
+	// TODO: Create Vm for client tests / optionally allow
+	// for running tests against a running Vm
+	vm := Vm{
+		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
+	}
+	diskNameLabel := fmt.Sprintf("%stesting", integrationTestPrefix)
+	diskId, err := c.CreateDisk(
+		vm,
+		Disk{
+			VBD{},
+			VDI{
+				NameLabel: diskNameLabel,
+				Size:      10000,
+				SrId:      accDefaultSr.Id,
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("failed to create disk with error: %v", err)
+	}
+
+	disks, err := c.GetDisks(&vm)
+
+	for _, disk := range disks {
+		if disk.NameLabel != diskNameLabel {
+			continue
+		}
+
+		err = c.DeleteDisk(vm, disk)
+
+		if err != nil {
+			t.Errorf("failed to delete disk with id: %s with error: %v", diskId, err)
+		}
+	}
+}

--- a/client/vdi_test.go
+++ b/client/vdi_test.go
@@ -26,7 +26,6 @@ func TestGetVmDisks(t *testing.T) {
 		t.Fatalf("failed to find disks for Vm")
 	}
 
-	fmt.Printf("Found disks with %+v", disks)
 	if !validateDisk(disks[0]) {
 		t.Errorf("failed to validate that disks contained expected data")
 	}

--- a/client/vdi_test.go
+++ b/client/vdi_test.go
@@ -12,11 +12,7 @@ func TestGetVmDisks(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	// TODO: Create Vm for client tests / optionally allow
-	// for running tests against a running Vm
-	disks, err := c.GetDisks(&Vm{
-		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
-	})
+	disks, err := c.GetDisks(&accVm)
 
 	if err != nil {
 		t.Fatalf("failed to get disks of VM with error: %v", err)
@@ -57,14 +53,9 @@ func TestCreateDiskAndDeleteDisk(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	// TODO: Create Vm for client tests / optionally allow
-	// for running tests against a running Vm
-	vm := Vm{
-		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
-	}
 	diskNameLabel := fmt.Sprintf("%stesting", integrationTestPrefix)
 	diskId, err := c.CreateDisk(
-		vm,
+		accVm,
 		Disk{
 			VBD{},
 			VDI{
@@ -79,14 +70,14 @@ func TestCreateDiskAndDeleteDisk(t *testing.T) {
 		t.Fatalf("failed to create disk with error: %v", err)
 	}
 
-	disks, err := c.GetDisks(&vm)
+	disks, err := c.GetDisks(&accVm)
 
 	for _, disk := range disks {
 		if disk.NameLabel != diskNameLabel {
 			continue
 		}
 
-		err = c.DeleteDisk(vm, disk)
+		err = c.DeleteDisk(accVm, disk)
 
 		if err != nil {
 			t.Errorf("failed to delete disk with id: %s with error: %v", diskId, err)
@@ -101,12 +92,7 @@ func TestDisconnectDiskAndConnectDisk(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	// TODO: Create Vm for client tests / optionally allow
-	// for running tests against a running Vm
-	vm := Vm{
-		Id: "75e7a443-f9c5-0afa-29ef-c15a33690a00",
-	}
-	disks, err := c.GetDisks(&vm)
+	disks, err := c.GetDisks(&accVm)
 
 	if err != nil {
 		t.Fatalf("failed to retrieve disks with error: %v", err)

--- a/client/vif_test.go
+++ b/client/vif_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"os"
 	"testing"
 )
 
@@ -13,9 +12,7 @@ func TestGetVIFs(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	vm := findVmForTest(c, t)
-
-	vifs, err := c.GetVIFs(&vm)
+	vifs, err := c.GetVIFs(&accVm)
 
 	for _, vif := range vifs {
 		if vif.Device == "" {
@@ -30,8 +27,8 @@ func TestGetVIFs(t *testing.T) {
 			t.Errorf("expecting `Network` field to be set on VIF")
 		}
 
-		if vif.VmId != vm.Id {
-			t.Errorf("VIF's VmId `%s` should have matched: %v", vif.VmId, vm)
+		if vif.VmId != accVm.Id {
+			t.Errorf("VIF's VmId `%s` should have matched: %v", vif.VmId, accVm)
 		}
 
 		if len(vif.Device) == 0 {
@@ -52,9 +49,7 @@ func TestGetVIF(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	vm := findVmForTest(c, t)
-
-	vifs, err := c.GetVIFs(&vm)
+	vifs, err := c.GetVIFs(&accVm)
 
 	expectedVIF := vifs[0]
 
@@ -71,47 +66,20 @@ func TestGetVIF(t *testing.T) {
 	}
 }
 
-func findVmForTest(c *Client, t *testing.T) Vm {
-
-	vms, err := c.GetVms()
-
-	if err != nil {
-		t.Fatalf("failed to get VMs with error: %v", err)
-	}
-
-	if len(vms) < 1 {
-		t.Fatalf("request returned %d vm results, expected atleast 1", len(vms))
-	}
-	return vms[0]
-}
-
 func TestCreateVIF_DeleteVIF(t *testing.T) {
-	if p := os.Getenv("XOA_POOL"); p != "xenserver-ddelnano" {
-		t.Skip("This test isn't safe to run outside of my personal deployment yet!")
-	}
-
 	c, err := NewClient(GetConfigFromEnv())
 
 	if err != nil {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	vmName := "XOA"
-	vm, err := c.GetVm(Vm{NameLabel: vmName})
+	vm, err := c.GetVm(accVm)
 
 	if err != nil {
 		t.Fatalf("failed to get VM with error: %v", err)
 	}
 
-	pifs, err := c.GetPIFByDevice("eth1", -1)
-
-	if err != nil {
-		t.Fatalf("failed to get PIF with error: %v", err)
-	}
-
-	pif := pifs[0]
-
-	vif, err := c.CreateVIF(vm, &VIF{Network: pif.Network})
+	vif, err := c.CreateVIF(vm, &VIF{Network: accDefaultNetwork.Id})
 
 	if err != nil {
 		t.Fatalf("failed to create VIF with error: %v", err)

--- a/client/vm.go
+++ b/client/vm.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -229,21 +230,54 @@ func (c *Client) waitForModifyVm(id string, timeout time.Duration) error {
 	return err
 }
 
-func FindVmForTests(vm *Vm, tag string) error {
+func FindOrCreateVmForTests(vm *Vm, srId, networkId, templateName, tag string) {
 	c, err := NewClient(GetConfigFromEnv())
 	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
+		fmt.Printf("failed to create client with error: %v\n", err)
+		os.Exit(-1)
 	}
 
-	vmRes, err := c.GetVm(Vm{
+	var vmRes *Vm
+	vmRes, err = c.GetVm(Vm{
 		Tags: []string{tag},
 	})
 
+	if _, ok := err.(NotFound); ok {
+		// Create Vm with the right tag and
+		// vmRes, err = c.CreateVm(
+		// 	fmt.Sprintf("%sterraform-testing", tag),
+		// 	"",
+		// 	templateName,
+		// 	"",
+		// 	"",
+		// 	1,
+		// 	2147483648,
+		// 	[]map[string]string{
+		// 		{
+		// 			"network_id": networkId,
+		// 		},
+		// 	},
+		// 	[]VDI{
+		// 		{
+		// 			SrId:      srId,
+		// 			NameLabel: "terraform xenorchestra client testing",
+		// 			Size:      16106127360,
+		// 		},
+		// 		{
+		// 			SrId:      srId,
+		// 			NameLabel: "disk2",
+		// 			Size:      16106127360,
+		// 		},
+		// 	},
+		// )
+		fmt.Println("Creating a vm for the client tests is not implemented yet")
+		os.Exit(-1)
+	}
+
 	if err != nil {
-		return err
+		fmt.Println(fmt.Sprintf("failed to find vm for the client tests with error: %v\n", err))
+		os.Exit(-1)
 	}
 
 	*vm = *vmRes
-
-	return nil
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -32,6 +32,7 @@ type Vm struct {
 	Memory             MemoryObject `json:"memory"`
 	PowerState         string       `json:"power_state"`
 	VIFs               []string     `json:"VIFs"`
+	VBDs               []string     `json:"$VBDs"`
 	VirtualizationMode string       `json:"virtualizationMode"`
 	PoolId             string       `json:"$poolId"`
 	Template           string       `json:"template"`
@@ -52,12 +53,6 @@ func (v Vm) Compare(obj interface{}) bool {
 	}
 
 	return false
-}
-
-type VDI struct {
-	SrId      string
-	NameLabel string
-	Size      int
 }
 
 func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, resourceSet string, cpus, memoryMax int, networks []map[string]string, disks []VDI) (*Vm, error) {

--- a/client/vm.go
+++ b/client/vm.go
@@ -79,12 +79,21 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		})
 	}
 	existingDisks := map[string]interface{}{}
+	vdis := []interface{}{}
 
 	for idx, disk := range disks {
-		existingDisks[fmt.Sprintf("%d", idx)] = map[string]interface{}{
+		d := map[string]interface{}{
 			"$SR":        disk.SrId,
 			"name_label": disk.NameLabel,
 			"size":       disk.Size,
+		}
+
+		if idx == 0 {
+			existingDisks[fmt.Sprintf("%d", idx)] = d
+		} else {
+			d["type"] = "user"
+			d["SR"] = disk.SrId
+			vdis = append(vdis, d)
 		}
 	}
 	params := map[string]interface{}{
@@ -98,6 +107,7 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 		"CPUs":             cpus,
 		"memoryMax":        memoryMax,
 		"existingDisks":    existingDisks,
+		"VDIs":             vdis,
 		"VIFs":             vifs,
 	}
 
@@ -243,6 +253,7 @@ func FindOrCreateVmForTests(vm *Vm, srId, networkId, templateName, tag string) {
 	})
 
 	if _, ok := err.(NotFound); ok {
+		// TODO: Create vm for use during tests (#90)
 		// Create Vm with the right tag and
 		// vmRes, err = c.CreateVm(
 		// 	fmt.Sprintf("%sterraform-testing", tag),

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -1,7 +1,6 @@
 package xoa
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -12,17 +11,12 @@ var testObjectIndex int = 1
 var accTestPrefix string = "terraform-acc"
 var accTestPool client.Pool
 var accDefaultSr client.StorageRepository
-var accTemplateName string
+var testTemplate client.Template
 
 func TestMain(m *testing.M) {
+	client.FindTemplateForTests(&testTemplate)
 	client.FindPoolForTests(&accTestPool)
 	client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
-	var found bool
-	accTemplateName, found = os.LookupEnv("XOA_TEMPLATE")
-	if !found {
-		fmt.Println("The XOA_TEMPLATE environment variable must be set for the tests")
-		os.Exit(-1)
-	}
 	code := m.Run()
 
 	client.RemoveNetworksWithNamePrefix(accTestPrefix)("")

--- a/xoa/data_source_xenorchestra_template_test.go
+++ b/xoa/data_source_xenorchestra_template_test.go
@@ -47,5 +47,5 @@ data "xenorchestra_template" "template" {
     name_label = "%s"
     pool_id = "%s"
 }
-`, accTemplateName, poolId)
+`, testTemplate.NameLabel, poolId)
 }

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -298,11 +298,9 @@ func disksToMapList(disks []client.Disk) []map[string]interface{} {
 			continue
 		}
 		diskMap := map[string]interface{}{
-			"attached": disk.Attached,
-			"vbd_id":   disk.Id,
-			"vdi_id":   disk.VDIId,
-			// "device":     disk.Device,
-			// "pool_id":    disk.PoolId,
+			"attached":   disk.Attached,
+			"vbd_id":     disk.Id,
+			"vdi_id":     disk.VDIId,
 			"position":   disk.Position,
 			"name_label": disk.NameLabel,
 			"size":       disk.Size,
@@ -428,7 +426,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		nSet := schema.NewSet(diskHash, nDisk.([]interface{}))
 
 		removals := expandDisks(oSet.Difference(nSet).List())
-		log.Printf("[DEBUG] Found the following network removals: %v previous set: %v new set: %v\n", oSet.Difference(nSet).List(), oSet, nSet)
+		log.Printf("[DEBUG] Found the following disk removals: %v previous set: %v new set: %v\n", oSet.Difference(nSet).List(), oSet, nSet)
 		for _, removal := range removals {
 
 			updateDisk := shouldUpdateDisk(removal, expandDisks(nSet.List()))
@@ -443,7 +441,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		}
 
 		additions := sortDiskByPostion(expandDisks(nSet.Difference(oSet).List()))
-		log.Printf("[DEBUG] Found the following network additions: %v previous set: %v new set: %v\n", nSet.Difference(oSet).List(), oSet, nSet)
+		log.Printf("[DEBUG] Found the following disk additions: %v previous set: %v new set: %v\n", nSet.Difference(oSet).List(), oSet, nSet)
 		for _, disk := range additions {
 
 			updateDisk := shouldUpdateDisk(disk, expandDisks(oSet.List()))

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -151,9 +151,6 @@ func resourceRecord() *schema.Resource {
 			"disk": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
-				// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// 	return false
-				// },
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sr_id": &schema.Schema{
@@ -578,7 +575,6 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, d 
 
 	disksMapList := disksToMapList(disks)
 	err = d.Set("disk", disksMapList)
-	fmt.Printf("Printing disksMapList: %+v with error: %+v\n", disksMapList, err)
 	if err != nil {
 		return err
 	}

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -751,7 +751,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfig() string {
@@ -783,7 +783,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10001317888
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfigDisconnectedDisk() string {
@@ -816,7 +816,7 @@ resource "xenorchestra_vm" "bar" {
       attached = false
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithAdditionalDisk() string {
@@ -854,7 +854,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10001317888
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id, accDefaultSr.Id)
 }
 
 func testAccVmVifAttachedConfig() string {
@@ -887,7 +887,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmVifDetachedConfig() string {
@@ -920,7 +920,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithMacAddress(macAddress string) string {
@@ -953,7 +953,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, macAddress, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, macAddress, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithTwoMacAddresses(firstMac, secondMac string) string {
@@ -991,7 +991,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, firstMac, secondMac, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, firstMac, secondMac, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithSecondVIF() string {
@@ -1032,7 +1032,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithThreeVIFs() string {
@@ -1076,7 +1076,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 // Terraform config that tests changes to a VM that do not require halting
@@ -1112,7 +1112,7 @@ resource "xenorchestra_vm" "bar" {
       size = 10000000000
     }
 }
-`, accTemplateName, accTestPool.Id, nameLabel, nameDescription, ha, powerOn, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, nameLabel, nameDescription, ha, powerOn, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithResourceSet() string {
@@ -1175,7 +1175,7 @@ resource "xenorchestra_resource_set" "rs" {
       quantity = 12884901888
     }
 }
-`, accTemplateName, accTestPool.Id, accDefaultSr.Id)
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
 }
 
 func testAccVmConfigWithoutResourceSet() string {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -369,6 +369,9 @@ func TestAccXenorchestraVm_attachDisconnectedDisk(t *testing.T) {
 
 		disks, err := c.GetDisks(vm)
 
+		// Sleep so that the VM has a change to load the PV drivers
+		time.Sleep(120 * time.Second)
+
 		if err != nil {
 			t.Fatalf("failed to retrieve the following vm's disks: %+v with error: %v", vm, err)
 		}
@@ -490,6 +493,9 @@ func TestAccXenorchestraVm_addAndRemoveDisksToVm(t *testing.T) {
 					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
 			},
 			{
+				PreConfig: func() {
+					time.Sleep(20 * time.Second)
+				},
 				Config: testAccVmConfigWithAdditionalDisk(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
@@ -498,6 +504,9 @@ func TestAccXenorchestraVm_addAndRemoveDisksToVm(t *testing.T) {
 					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
 			},
 			{
+				PreConfig: func() {
+					time.Sleep(20 * time.Second)
+				},
 				Config: testAccVmConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
@@ -768,7 +777,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -904,7 +913,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -937,7 +946,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -970,7 +979,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, macAddress, accDefaultSr.Id)
@@ -1008,7 +1017,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, firstMac, secondMac, accDefaultSr.Id)
@@ -1049,7 +1058,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -1093,7 +1102,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -1129,7 +1138,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, nameLabel, nameDescription, ha, powerOn, accDefaultSr.Id)
@@ -1153,7 +1162,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, accDefaultSr.Id)
@@ -1215,7 +1224,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10000000000
+      size = 10001317888
     }
 }
 `, accDefaultSr.Id)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -454,6 +454,26 @@ func TestAccXenorchestraVm_disconnectAttachedDisk(t *testing.T) {
 	})
 }
 
+func TestAccXenorchestraVm_createWithMutipleDisks(t *testing.T) {
+	resourceName := "xenorchestra_vm.bar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmConfigWithAdditionalDisk(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "disk.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "disk.0.attached", "true"),
+					resource.TestCheckResourceAttr(resourceName, "disk.1.attached", "true")),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_addAndRemoveDisksToVm(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This addresses #33

## Todo
- [x] `make testacc` passes
- [x] Allow client package tests to use a running VM
- [x] Allow using a running vm for the client package tests.
- [x] Create issue for creating a vm for client tests if a suitable VM is not already running (#90)