### PR TITLE
Add support for specifying the cloud init network configuration on the xenorchestra_vm resource

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -70,7 +70,7 @@ func (v Vm) Compare(obj interface{}) bool {
 	return false
 }
 
-func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, resourceSet string, cpus, memoryMax int, networks []map[string]string, disks []VDI) (*Vm, error) {
+func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, cloudNetworkConfig, resourceSet string, cpus, memoryMax int, networks []map[string]string, disks []VDI) (*Vm, error) {
 	vifs := []map[string]string{}
 	for _, network := range networks {
 		vifs = append(vifs, map[string]string{
@@ -117,6 +117,10 @@ func (c *Client) CreateVm(name_label, name_description, template, cloudConfig, r
 
 	if resourceSet != "" {
 		params["resourceSet"] = resourceSet
+	}
+
+	if cloudNetworkConfig != "" {
+		params["networkConfig"] = cloudNetworkConfig
 	}
 	log.Printf("[DEBUG] VM params for vm.create %#v", params)
 	var vmId string

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -49,7 +49,8 @@ resource "xenorchestra_vm" "bar" {
 * name_label - (Required) The name of VM.
 * name_description - (Optional) The description of the VM.
 * template - (Required) The ID of the VM template to create the new VM from.
-* cloud_config - (Optional) The content of the cloud config to use
+* cloud_config - (Optional) The content of the cloud-init config to use
+* cloud_network_config - (Optional) The content of the cloud-init network configuration for the VM (uses [version 1](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html))
 * cpus - (Required) The number of CPUs the VM will have.
 * memory_max - (Required) The amount of memory in bytes the VM will have.
 * high_availabililty - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -65,6 +65,10 @@ func resourceRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"cloud_network_config": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"auto_poweron": &schema.Schema{
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -223,6 +227,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		d.Get("name_description").(string),
 		d.Get("template").(string),
 		d.Get("cloud_config").(string),
+		d.Get("cloud_network_config").(string),
 		d.Get("resource_set").(string),
 		d.Get("cpus").(int),
 		d.Get("memory_max").(int),


### PR DESCRIPTION
This addresses #34 

## Todo
- [x] `make testacc` passes
