### PR TITLE
Fix issue finding the correct memory_max, add the attribute to the vm resource's state 

### DIFF
--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -538,12 +538,14 @@ func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData
 func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, d *schema.ResourceData) error {
 	d.SetId(resource.Id)
 	// d.Set("cloud_config", resource.CloudConfig)
-	// err := d.Set("memory_max", resource.Memory.Size)
-	// log.Printf("[DEBUG] Found error when setting memory_max %+v", err)
+	if len(resource.Memory.Static) == 2 {
+		if err := d.Set("memory_max", resource.Memory.Static[1]); err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[WARN] Expected the VM's static memory limits to have two values, %v found instead\n", resource.Memory.Static)
+	}
 
-	// if err != nil {
-	// 	return err
-	// }
 	d.Set("cpus", resource.CPUs.Number)
 	d.Set("name_label", resource.NameLabel)
 	d.Set("name_description", resource.NameDescription)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -315,6 +315,7 @@ func TestAccXenorchestraVm_createAndUpdateDiskNameLabelAndNameDescription(t *tes
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "memory_max", "4295000000"),
 					resource.TestCheckResourceAttr(resourceName, "disk.0.name_label", nameLabel),
 					resource.TestCheckResourceAttr(resourceName, "disk.0.name_description", description)),
 			},


### PR DESCRIPTION
This addresses #103 which causes confusion when importing VM's into terraform.

## Todo
- [x] `make testacc` passes