### PR TITLE
Allow skipping ssl verification with XOA_INSECURE or insecure parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ provider "xenorchestra" {
   url      = "ws://hostname-of-server" # Or set XOA_URL environment variable
   username = "<username>"              # Or set XOA_USER environment variable
   password = "<password>"              # Or set XOA_PASSWORD environment variable
-
+}
 ```
 
 3. Ensure the provider is properly installed with a `terraform init`.
@@ -37,9 +37,24 @@ terraform {
   required_providers {
     xenorchestra = {
       source = "terra-farm/xenorchestra"
-      version = "~> 0.5"
+      version = "~> 0.3.0"
     }
   }
+}
+
+# Configure the XenServer Provider
+provider "xenorchestra" {
+  # Must be ws or wss
+  url      = "ws://hostname-of-server" # Or set XOA_URL environment variable
+  username = "<username>"              # Or set XOA_USER environment variable
+  password = "<password>"              # Or set XOA_PASSWORD environment variable
+
+  # This is false by default and
+  # will disable ssl verification if true.
+  # This is useful if your deployment uses
+  # a self signed certificate but should be
+  # used sparingly!
+  insecure = <false|true>              # Or set XOA_INSECURE environment variable to any value
 }
 ```
 

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -27,6 +27,13 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("XOA_PASSWORD", nil),
 				Description: "Password for xoa api",
 			},
+			"insecure": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("XOA_INSECURE", nil),
+				Description: "Whether SSL should be verified or not",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"xenorchestra_acl":          resourceAcl(),
@@ -51,10 +58,12 @@ func xoaConfigure(d *schema.ResourceData) (interface{}, error) {
 	url := d.Get("url").(string)
 	username := d.Get("username").(string)
 	password := d.Get("password").(string)
+	insecure := d.Get("insecure").(bool)
 	config := client.Config{
-		Url:      url,
-		Username: username,
-		Password: password,
+		Url:                url,
+		Username:           username,
+		Password:           password,
+		InsecureSkipVerify: insecure,
 	}
 	return client.NewClient(config)
 }


### PR DESCRIPTION
This addresses #102.

## Testing
- [x] Verified that ssl fails when environment variable is not set
- [x] Verified that requests are successful when `XOA_INSECURE` is set