### PR TITLE
Add affinity host attribute to vm resource

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -27,6 +27,7 @@ type MemoryObject struct {
 type Vm struct {
 	Type               string       `json:"type,omitempty"`
 	Id                 string       `json:"id,omitempty"`
+	AffinityHost       string       `json:"affinityHost,omitempty"`
 	NameDescription    string       `json:"name_description"`
 	NameLabel          string       `json:"name_label"`
 	CPUs               CPUs         `json:"CPUs"`
@@ -98,6 +99,7 @@ func (c *Client) CreateVm(vmReq Vm) (*Vm, error) {
 		}
 	}
 	params := map[string]interface{}{
+		"affinityHost":     vmReq.AffinityHost,
 		"bootAfterCreate":  true,
 		"name_label":       vmReq.NameLabel,
 		"name_description": vmReq.NameDescription,

--- a/client/vm.go
+++ b/client/vm.go
@@ -150,7 +150,7 @@ func (c *Client) CreateVm(vmReq Vm) (*Vm, error) {
 	)
 }
 
-func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, rs string, autoPowerOn bool) (*Vm, error) {
+func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, rs string, autoPowerOn bool, affinityHost string) (*Vm, error) {
 
 	var resourceSet interface{} = rs
 	if rs == "" {
@@ -158,6 +158,7 @@ func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, r
 	}
 	params := map[string]interface{}{
 		"id":                id,
+		"affinityHost":      affinityHost,
 		"name_label":        nameLabel,
 		"name_description":  nameDescription,
 		"auto_poweron":      autoPowerOn,
@@ -167,7 +168,7 @@ func (c *Client) UpdateVm(id string, cpus int, nameLabel, nameDescription, ha, r
 		// "CPUs":             cpus,
 		// "memoryMax": memoryMax,
 		// TODO: These need more investigation before they are implemented
-		// pv_args, cpuMask cpuWeight cpuCap affinityHost vga videoram coresPerSocket hasVendorDevice expNestedHvm resourceSet share startDelay nicType hvmBootFirmware virtualizationMode
+		// pv_args, cpuMask cpuWeight cpuCap vga videoram coresPerSocket hasVendorDevice expNestedHvm share startDelay nicType hvmBootFirmware virtualizationMode
 	}
 	log.Printf("[DEBUG] VM params for vm.set: %#v", params)
 	var success bool

--- a/docs/data-sources/pool.md
+++ b/docs/data-sources/pool.md
@@ -20,6 +20,7 @@ data "xenorchestra_sr" "local_storage" {
 ## Attributes Reference
 * id - Id of the pool.
 * description - The description of the pool.
+* master - The id of the primary instance in the pool.
 * cpus - CPU information about the pool.
     * cores - Number of cores in the pool.
     * sockets - Number of sockets in the pool.

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -5,6 +5,10 @@ Creates a Xen Orchestra vm resource.
 ## Example Usage
 
 ```hcl
+data "xenorchestra_pool" "pool" {
+    name_label = "pool name"
+}
+
 data "xenorchestra_template" "template" {
     name_label = "Puppet agent - Bionic 18.04 - 1"
 }
@@ -34,6 +38,8 @@ resource "xenorchestra_vm" "bar" {
     name_description = "description"
     template = data.xenorchestra_template.template.id
 
+    # Prefer to run the VM on the primary pool instance
+    affinity_host = data.xenorchestra_pool.pool.master
     # TODO: Add affinity_host example
     network {
       network_id = data.xenorchestra_network.net.id
@@ -62,7 +68,7 @@ resource "xenorchestra_vm" "bar" {
 * memory_max - (Required) The amount of memory in bytes the VM will have.
 * high_availabililty - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.
 * auto_poweron - (Optional) If the VM will automatically turn on. Defaults to `false`.
-* affinity_host - (Optional) The preferred host you would like the VM to run on
+* affinity_host - (Optional) The preferred host you would like the VM to run on. If changed on an existing VM it will require a reboot for the VM to be rescheduled.
 * network - (Required) The network the VM will use
     * network_id - (Required) The ID of the network the VM will be on.
     * mac_address - (Optional) The mac address of the network interaface

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -40,7 +40,6 @@ resource "xenorchestra_vm" "bar" {
 
     # Prefer to run the VM on the primary pool instance
     affinity_host = data.xenorchestra_pool.pool.master
-    # TODO: Add affinity_host example
     network {
       network_id = data.xenorchestra_network.net.id
     }

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -33,8 +33,10 @@ resource "xenorchestra_vm" "bar" {
     name_label = "Name"
     name_description = "description"
     template = data.xenorchestra_template.template.id
+
+    # TODO: Add affinity_host example
     network {
-	  network_id = data.xenorchestra_network.net.id
+      network_id = data.xenorchestra_network.net.id
     }
 
     disk {
@@ -60,6 +62,7 @@ resource "xenorchestra_vm" "bar" {
 * memory_max - (Required) The amount of memory in bytes the VM will have.
 * high_availabililty - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.
 * auto_poweron - (Optional) If the VM will automatically turn on. Defaults to `false`.
+* affinity_host - (Optional) The preferred host you would like the VM to run on
 * network - (Required) The network the VM will use
     * network_id - (Required) The ID of the network the VM will be on.
     * mac_address - (Optional) The mac address of the network interaface

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -21,6 +21,10 @@ func dataSourceXoaPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"master": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"cpus": &schema.Schema{
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -62,6 +66,10 @@ func dataSourcePoolRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", pool.Description)
 	err = d.Set("cpus", cpus)
 	if err != nil {
+		return err
+	}
+
+	if err := d.Set("master", pool.Master); err != nil {
 		return err
 	}
 	return nil

--- a/xoa/data_source_pool.go
+++ b/xoa/data_source_pool.go
@@ -63,7 +63,9 @@ func dataSourcePoolRead(d *schema.ResourceData, m interface{}) error {
 		"sockets": fmt.Sprintf("%d", pool.Cpus.Sockets),
 		"cores":   fmt.Sprintf("%d", pool.Cpus.Cores),
 	}
-	d.Set("description", pool.Description)
+	if err := d.Set("description", pool.Description); err != nil {
+		return err
+	}
 	err = d.Set("cpus", cpus)
 	if err != nil {
 		return err

--- a/xoa/data_source_pool_test.go
+++ b/xoa/data_source_pool_test.go
@@ -20,7 +20,7 @@ func TestAccXenorchestraDataSource_pool(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourcePool(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					// resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "master"),
 					resource.TestCheckResourceAttr(resourceName, "cpus.%", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "cpus.sockets"),
 					resource.TestCheckResourceAttrSet(resourceName, "cpus.cores"),

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -374,12 +374,13 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 
 	id := d.Id()
 	nameLabel := d.Get("name_label").(string)
+	affinityHost := d.Get("affinity_host").(string)
 	nameDescription := d.Get("name_description").(string)
 	cpus := d.Get("cpus").(int)
 	autoPowerOn := d.Get("auto_poweron").(bool)
 	ha := d.Get("high_availability").(string)
 	rs := d.Get("resource_set").(string)
-	vm, err := c.UpdateVm(id, cpus, nameLabel, nameDescription, ha, rs, autoPowerOn)
+	vm, err := c.UpdateVm(id, cpus, nameLabel, nameDescription, ha, rs, autoPowerOn, affinityHost)
 	log.Printf("[DEBUG] Retrieved vm after update: %+v\n", vm)
 
 	if err != nil {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -36,6 +36,10 @@ func resourceRecord() *schema.Resource {
 			Update: &duration,
 		},
 		Schema: map[string]*schema.Schema{
+			"affinity_host": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"name_label": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -217,6 +221,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	vm, err := c.CreateVm(client.Vm{
+		AffinityHost:    d.Get("affinity_host").(string),
 		NameLabel:       d.Get("name_label").(string),
 		NameDescription: d.Get("name_description").(string),
 		Template:        d.Get("template").(string),
@@ -588,6 +593,7 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, d 
 
 	d.Set("cpus", resource.CPUs.Number)
 	d.Set("name_label", resource.NameLabel)
+	d.Set("affinity_host", resource.AffinityHost)
 	d.Set("name_description", resource.NameDescription)
 	d.Set("high_availability", resource.HA)
 	d.Set("auto_poweron", resource.AutoPoweron)


### PR DESCRIPTION
This is a start for implementing #109 and also refactors how the xoa client creates Vms since the growing number of parameters to the method was becoming unwieldy.

## Todo
- [x] Understand how updates should work and implement them
- [x] Understand how this attributes value should be retrieved (new `host` data source, using hosts from the `pool` data source, etc)
- [x] Update docs to include an example
- [x] `make testacc` passes