### PR TITLE
Ensure that the xenorchestra_vm resource formats mac addresses properly before making requests to the XO api

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -70,7 +70,7 @@ resource "xenorchestra_vm" "bar" {
 * affinity_host - (Optional) The preferred host you would like the VM to run on. If changed on an existing VM it will require a reboot for the VM to be rescheduled.
 * network - (Required) The network the VM will use
     * network_id - (Required) The ID of the network the VM will be on.
-    * mac_address - (Optional) The mac address of the network interaface
+    * mac_address - (Optional) The mac address of the network interface. This must be parsable by go's [net.ParseMAC function](https://golang.org/pkg/net/#ParseMAC). All mac addresses are stored in Terraform's state with [HardwareAddr's string representation](https://golang.org/pkg/net/#HardwareAddr.String) i.e. 00:00:5e:00:53:01
 * disk - (Required) The disk the VM will have access to.
     * sr_id - (Required) The storage repository ID to use.
     * name_label - (Required) The name for the disk.

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -417,6 +417,30 @@ func TestAccXenorchestraVm_createWithCloudInitNetworkConfig(t *testing.T) {
 	})
 }
 
+func TestAccXenorchestraVm_createWithDashedMacAddress(t *testing.T) {
+	resourceName := "xenorchestra_vm.bar"
+	macWithDashes := "00-0a-83-b1-c0-01"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmConfigWithMacAddress(macWithDashes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network.#", "1"),
+					internal.TestCheckTypeSetElemNestedAttrs(resourceName, "network.*", map[string]string{
+						// All mac addresses should be formatted to use colons
+						"mac_address": getFormattedMac(macWithDashes),
+					}),
+					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	macAddress := "00:0a:83:b1:c0:83"

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -463,9 +463,6 @@ func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
 			},
 			{
-				PreConfig: func() {
-					time.Sleep(60 * time.Second)
-				},
 				Config: testAccVmConfigWithMacAddress(otherMacAddress),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
@@ -1003,7 +1000,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10001317888
+      size = 10737418240
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1000,7 +1000,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10737418240
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
@@ -1375,7 +1375,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10737418240
+      size = 10001317888
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, macAddress, accDefaultSr.Id)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -421,6 +421,7 @@ func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	macAddress := "00:0a:83:b1:c0:83"
 	otherMacAddress := "00:0a:83:b1:c0:00"
+	macWithDashes := "00-0a-83-b1-c0-01"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -438,6 +439,9 @@ func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
 			},
 			{
+				PreConfig: func() {
+					time.Sleep(60 * time.Second)
+				},
 				Config: testAccVmConfigWithMacAddress(otherMacAddress),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
@@ -445,6 +449,18 @@ func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network.#", "1"),
 					internal.TestCheckTypeSetElemNestedAttrs(resourceName, "network.*", map[string]string{
 						"mac_address": otherMacAddress,
+					}),
+					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
+			},
+			{
+				Config: testAccVmConfigWithMacAddress(macWithDashes),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "network.#", "1"),
+					internal.TestCheckTypeSetElemNestedAttrs(resourceName, "network.*", map[string]string{
+						// All mac addresses should be formatted to use colons
+						"mac_address": getFormattedMac(macWithDashes),
 					}),
 					internal.TestCheckTypeSetElemAttrPair(resourceName, "network.*.*", "data.xenorchestra_network.network", "id")),
 			},
@@ -1338,7 +1354,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10001317888
+      size = 10737418240
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, macAddress, accDefaultSr.Id)


### PR DESCRIPTION
This is to address #114 

# Todo
- [x] Add a test for vm creation with a differently formatted mac address
- [x] Add a test for vm vif updates with a differently formatted mac address
- [x] Updated documentation to highlight how mac addresses are parsed and how they are stored in state.
- [x] `make testacc` passes