### PR TITLE
Add docs and implement the cloud config data source

### DIFF
--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -31,32 +31,24 @@ type CloudConfigResponse struct {
 }
 
 func (c *Client) GetCloudConfig(id string) (*CloudConfig, error) {
-	params := map[string]interface{}{
-		"id": id,
-	}
-	var getAllResp CloudConfigResponse
-	err := c.Call("cloudConfig.getAll", params, &getAllResp.Result)
+	cloudConfigs, err := c.GetAllCloudConfigs()
 
 	if err != nil {
 		return nil, err
 	}
 
 	cloudConfig := CloudConfig{Id: id}
-	for _, config := range getAllResp.Result {
+	for _, config := range cloudConfigs {
 		if cloudConfig.Compare(config) {
 			return &config, nil
 		}
 	}
 
-	return nil, NotFound{Query: cloudConfig}
+	return nil, nil
 }
 
 func (c *Client) GetCloudConfigByName(name string) ([]CloudConfig, error) {
-	params := map[string]interface{}{
-		"name": name,
-	}
-	var getAllResp CloudConfigResponse
-	err := c.Call("cloudConfig.getAll", params, &getAllResp.Result)
+	allCloudConfigs, err := c.GetAllCloudConfigs()
 
 	if err != nil {
 		return nil, err
@@ -64,7 +56,7 @@ func (c *Client) GetCloudConfigByName(name string) ([]CloudConfig, error) {
 
 	cloudConfigs := []CloudConfig{}
 	cloudConfig := CloudConfig{Name: name}
-	for _, config := range getAllResp.Result {
+	for _, config := range allCloudConfigs {
 		if cloudConfig.Compare(config) {
 			cloudConfigs = append(cloudConfigs, config)
 		}
@@ -101,15 +93,14 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 
 	// Since the Id isn't returned in the reponse loop over all cloud configs
 	// and find the one we just created
-	var getAllResp CloudConfigResponse
-	err = c.Call("cloudConfig.getAll", params, &getAllResp.Result)
+	cloudConfigs, err := c.GetAllCloudConfigs()
 
 	if err != nil {
 		return nil, err
 	}
 
 	var found CloudConfig
-	for _, config := range getAllResp.Result {
+	for _, config := range cloudConfigs {
 		if config.Name == name && config.Template == template {
 			found = config
 		}

--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -44,6 +44,8 @@ func (c *Client) GetCloudConfig(id string) (*CloudConfig, error) {
 		}
 	}
 
+	// TODO: This should return a NotFound error (see https://github.com/terra-farm/terraform-provider-xenorchestra/issues/118)
+	// for more details
 	return nil, nil
 }
 

--- a/docs/data-sources/cloud_config.md
+++ b/docs/data-sources/cloud_config.md
@@ -1,0 +1,22 @@
+# xenorchestra_cloud_config
+
+Provides information about cloud config.
+
+## Example Usage
+
+```hcl
+data "xenorchestra_cloud_config" "cloud_config" {
+  name = "Name of cloud config"
+}
+```
+
+## Argument Reference
+* name - (Required) The name of the cloud config you want to look up.
+
+~> **NOTE:** If there are multiple cloud configs with the same name
+Terraform will fail. Ensure that your names are unique when
+using the data source.
+
+
+## Attributes Reference
+* id - Id of the resource set.

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 	client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
 	client.RemoveTagFromAllObjects(accTestPrefix)("")
 	client.RemoveUsersWithPrefix(accTestPrefix)("")
+	client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
 
 	os.Exit(code)
 }

--- a/xoa/data_source_cloud_config.go
+++ b/xoa/data_source_cloud_config.go
@@ -1,0 +1,57 @@
+package xoa
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceXoaCloudConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCloudConfigRead,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"template": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudConfigRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*client.Client)
+
+	name := d.Get("name").(string)
+
+	cloudConfigs, err := c.GetCloudConfigByName(name)
+
+	if _, ok := err.(client.NotFound); ok {
+		d.SetId("")
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+
+	l := len(cloudConfigs)
+	if l != 1 {
+		return errors.New(fmt.Sprintf("found `%d` cloud configs with name `%s`. Cloud configs must be uniquely named to use this data source", l, name))
+	}
+
+	cloudConfig := cloudConfigs[0]
+
+	log.Printf("[DEBUG] Found cloud config with %+v", cloudConfig)
+	d.SetId(cloudConfig.Id)
+	if err := d.Set("template", cloudConfig.Template); err != nil {
+		return err
+	}
+	return nil
+}

--- a/xoa/data_source_cloud_config_test.go
+++ b/xoa/data_source_cloud_config_test.go
@@ -1,0 +1,106 @@
+package xoa
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccXenorchestraDataSource_cloudConfig(t *testing.T) {
+	resourceName := "data.xenorchestra_cloud_config.config"
+	cloudConfigName := fmt.Sprintf("%s-cloud-config-data-source-test", accTestPrefix)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: createCloudConfig(t, cloudConfigName),
+				Config:    testAccXenorchestraDataSourceCloudConfigConfig(cloudConfigName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckXenorchestraDataSourceCloudConfig(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id")),
+			},
+		},
+	},
+	)
+}
+
+func TestAccXenorchestraDataSource_cloudConfigProvidesErrorWhenNotFound(t *testing.T) {
+	cloudConfigName := "Does not exist"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccXenorchestraDataSourceCloudConfigConfig(cloudConfigName),
+				ExpectError: regexp.MustCompile("Could not find client.CloudConfig with query"),
+			},
+		},
+	},
+	)
+}
+
+func TestAccXenorchestraDataSource_cloudConfigErrorsWhenNonUniqueNamesExist(t *testing.T) {
+	cloudConfigName := resource.PrefixedUniqueId(fmt.Sprintf("%s-cloud-config-data-source-test", accTestPrefix))
+	c := createCloudConfig(t, cloudConfigName)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					for i := 0; i < 2; i++ {
+						c()
+					}
+				},
+				Config:      testAccXenorchestraDataSourceCloudConfigConfig(cloudConfigName),
+				ExpectError: regexp.MustCompile("found `2` cloud configs with name"),
+			},
+		},
+	},
+	)
+}
+
+func testAccCheckXenorchestraDataSourceCloudConfig(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find CloudConfig data source: %s", n)
+		}
+
+		log.Printf("[DEBUG] Found resource again %v", s.RootModule().Resources)
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("CloudConfig data source ID not set")
+		}
+		return nil
+	}
+}
+
+func createCloudConfig(t *testing.T, name string) func() {
+	return func() {
+		c, err := client.NewClient(client.GetConfigFromEnv())
+
+		if err != nil {
+			t.Fatalf("failed to created client with error: %v", err)
+		}
+
+		_, err = c.CreateCloudConfig(name, "Terraform acceptance testing template")
+
+		if err != nil {
+			t.Fatalf("failed to create cloud config for test with error: %v", err)
+		}
+	}
+}
+
+func testAccXenorchestraDataSourceCloudConfigConfig(cloudConfigName string) string {
+	return fmt.Sprintf(`
+data "xenorchestra_cloud_config" "config" {
+    name = "%s"
+}
+`, cloudConfigName)
+}

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -42,6 +42,7 @@ func Provider() terraform.ResourceProvider {
 			"xenorchestra_resource_set": resourceResourceSet(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"xenorchestra_cloud_config": dataSourceXoaCloudConfig(),
 			"xenorchestra_network":      dataSourceXoaNetwork(),
 			"xenorchestra_pif":          dataSourceXoaPIF(),
 			"xenorchestra_pool":         dataSourceXoaPool(),


### PR DESCRIPTION
This implements #113

## Todo
- [x] New tests pass
- [x] Refactor cloud config client code to reuse the same `cloudConfig.getAll` method
- [x] Add docs for the data source 