### PR TITLE
adds host data source

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -141,6 +141,8 @@ func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
 		xoApiType = "PIF"
 	case Pool:
 		xoApiType = "pool"
+	case Host:
+		xoApiType = "host"
 	case StorageRepository:
 		xoApiType = "SR"
 	case Vm:

--- a/client/host.go
+++ b/client/host.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
@@ -12,6 +13,10 @@ type Host struct {
 
 func (h Host) Compare(obj interface{}) bool {
 	otherHost := obj.(Host)
+	if otherHost.Id == h.Id {
+		return true
+	}
+
 	if otherHost.NameLabel != "" && h.NameLabel == otherHost.NameLabel {
 		return true
 	}
@@ -26,30 +31,37 @@ func (c *Client) GetHostByName(nameLabel string) (hosts []Host, err error) {
 	return obj.([]Host), nil
 }
 
-func FindHostForTests(host *Host) {
-	hostName, found := os.LookupEnv("XOA_HOST")
-
-	if !found {
-		fmt.Println("The XOA_HOST environment variable must be set")
-		os.Exit(-1)
+func (c *Client) GetHostById(id string) (host Host, err error) {
+	obj, err := c.FindFromGetAllObjects(Host{Id: id})
+	if err != nil {
+		return
 	}
+	hosts, ok := obj.([]Host)
+
+	if !ok {
+		return host, errors.New("failed to coerce response into Host slice")
+	}
+
+	if len(hosts) != 1 {
+		return host, errors.New(fmt.Sprintf("expected a single host to be returned, instead received: %d in the response: %v", len(hosts), obj))
+	}
+
+	return hosts[0], nil
+}
+
+func FindHostForTests(hostId string, host *Host) {
 	c, err := NewClient(GetConfigFromEnv())
 	if err != nil {
 		fmt.Printf("failed to create client with error: %v", err)
 		os.Exit(-1)
 	}
 
-	hosts, err := c.GetHostByName(hostName)
+	queriedHost, err := c.GetHostById(hostId)
 
 	if err != nil {
-		fmt.Printf("failed to find a hosts with name: %v with error: %v\n", hostName, err)
+		fmt.Printf("failed to find a host with id: %v with error: %v\n", hostId, err)
 		os.Exit(-1)
 	}
 
-	if len(hosts) != 1 {
-		fmt.Printf("Found %d hosts with name_label %s. Please use a label that is unique so tests are reproducible.\n", len(hosts), hostName)
-		os.Exit(-1)
-	}
-
-	*host = hosts[0]
+	*host = queriedHost
 }

--- a/client/host.go
+++ b/client/host.go
@@ -1,0 +1,22 @@
+package client
+
+type Host struct {
+	Id        string `json:"id"`
+	NameLabel string `json:"name_label"`
+}
+
+func (h Host) Compare(obj interface{}) bool {
+	otherHost := obj.(Host)
+	if otherHost.NameLabel != "" && h.NameLabel == otherHost.NameLabel {
+		return true
+	}
+	return false
+}
+
+func (c *Client) GetHostByName(nameLabel string) (hosts []Host, err error) {
+	obj, err := c.FindFromGetAllObjects(Host{NameLabel: nameLabel})
+	if err != nil {
+		return
+	}
+	return obj.([]Host), nil
+}

--- a/client/host.go
+++ b/client/host.go
@@ -1,5 +1,10 @@
 package client
 
+import (
+	"fmt"
+	"os"
+)
+
 type Host struct {
 	Id        string `json:"id"`
 	NameLabel string `json:"name_label"`
@@ -19,4 +24,32 @@ func (c *Client) GetHostByName(nameLabel string) (hosts []Host, err error) {
 		return
 	}
 	return obj.([]Host), nil
+}
+
+func FindHostForTests(host *Host) {
+	hostName, found := os.LookupEnv("XOA_HOST")
+
+	if !found {
+		fmt.Println("The XOA_HOST environment variable must be set")
+		os.Exit(-1)
+	}
+	c, err := NewClient(GetConfigFromEnv())
+	if err != nil {
+		fmt.Printf("failed to create client with error: %v", err)
+		os.Exit(-1)
+	}
+
+	hosts, err := c.GetHostByName(hostName)
+
+	if err != nil {
+		fmt.Printf("failed to find a hosts with name: %v with error: %v\n", hostName, err)
+		os.Exit(-1)
+	}
+
+	if len(hosts) != 1 {
+		fmt.Printf("Found %d hosts with name_label %s. Please use a label that is unique so tests are reproducible.\n", len(hosts), hostName)
+		os.Exit(-1)
+	}
+
+	*host = hosts[0]
 }

--- a/client/host_test.go
+++ b/client/host_test.go
@@ -38,20 +38,17 @@ func TestHostCompare(t *testing.T) {
 
 func TestGetHostByName(t *testing.T) {
 	c, err := NewClient(GetConfigFromEnv())
-
 	if err != nil {
-		t.Errorf("failed to create client with error: %v", err)
+		t.Fatalf("failed to create client with error: %v", err)
 	}
 
 	nameLabel := accTestHost.NameLabel
 	hosts, err := c.GetHostByName(nameLabel)
-
-	host := hosts[0]
-
 	if err != nil {
-		t.Errorf("failed to get host with error: %v", err)
+		t.Fatalf("failed to get host with error: %v", err)
 	}
 
+	host := hosts[0]
 	if host.NameLabel != nameLabel {
 		t.Errorf("expected host to have name `%s` received `%s` instead.", nameLabel, host.NameLabel)
 	}

--- a/client/host_test.go
+++ b/client/host_test.go
@@ -1,0 +1,59 @@
+package client
+
+import "testing"
+
+func TestHostCompare(t *testing.T) {
+	tests := []struct {
+		other  Host
+		host   Host
+		result bool
+	}{
+		{
+			other: Host{
+				Id:        "788e1dce-44f6-4db7-ae62-185c69fecd3b",
+				NameLabel: "xcp-host1-k8s.domain.eu",
+			},
+			host:   Host{NameLabel: "xcp-host1-k8s.domain.eu"},
+			result: true,
+		},
+		{
+			other: Host{
+				Id:        "788e1dce-44f6-4db7-ae62-185c69fecd3b",
+				NameLabel: "xcp-host2-k8s.domain.eu",
+			},
+			host:   Host{NameLabel: "xcp-host1-k8s.domain.eu"},
+			result: false,
+		},
+	}
+
+	for _, test := range tests {
+		host := test.host
+		other := test.other
+		result := test.result
+		if host.Compare(other) != result {
+			t.Errorf("Expected Host %v to Compare %t to %v", host, result, other)
+		}
+	}
+}
+
+func TestGetHostByName(t *testing.T) {
+	c, err := NewClient(GetConfigFromEnv())
+
+	if err != nil {
+		t.Errorf("failed to create client with error: %v", err)
+	}
+
+	nameLabel := accTestPool.NameLabel
+	hosts, err := c.GetHostByName(nameLabel)
+
+	host := hosts[0]
+
+	if err != nil {
+		t.Errorf("failed to get host with error: %v", err)
+	}
+
+	if host.NameLabel != nameLabel {
+		t.Errorf("expected host to have name `%s` received `%s` instead.", nameLabel, host.NameLabel)
+	}
+
+}

--- a/client/host_test.go
+++ b/client/host_test.go
@@ -43,7 +43,7 @@ func TestGetHostByName(t *testing.T) {
 		t.Errorf("failed to create client with error: %v", err)
 	}
 
-	nameLabel := accTestPool.NameLabel
+	nameLabel := accTestHost.NameLabel
 	hosts, err := c.GetHostByName(nameLabel)
 
 	host := hosts[0]

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -36,6 +36,7 @@ func CreateNetwork(network *Network) error {
 
 var integrationTestPrefix string = "xenorchestra-client-"
 var accTestPool Pool
+var accTestHost Host
 var accDefaultSr StorageRepository
 var accDefaultNetwork Network
 var testTemplate Template
@@ -45,6 +46,7 @@ func TestMain(m *testing.M) {
 
 	FindTemplateForTests(&testTemplate)
 	FindPoolForTests(&accTestPool)
+	FindHostForTests(&accTestHost)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
 	CreateNetwork(&accDefaultNetwork)
 	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, accDefaultNetwork.Id, testTemplate.Id, integrationTestPrefix)

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 
 	FindTemplateForTests(&testTemplate)
 	FindPoolForTests(&accTestPool)
-	FindHostForTests(&accTestHost)
+	FindHostForTests(accTestPool.Master, &accTestHost)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
 	CreateNetwork(&accDefaultNetwork)
 	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, accDefaultNetwork.Id, testTemplate.Id, integrationTestPrefix)

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -19,5 +19,9 @@ resource "xenorchestra_vm" "node" {
 ## Argument Reference
 * name_label - (Required) The name of the host you want to look up.
 
+~> **NOTE:** If there are multiple hosts with the same name
+Terraform will fail. Ensure that your names are unique when
+using the data source.
+
 ## Attributes Reference
 * id - Id of the host.

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -1,0 +1,23 @@
+# xenorchestra_host
+
+Provides information about a host.
+
+## Example Usage
+
+```hcl
+data "xenorchestra_host" "host1" {
+  name_label = "Your host"
+}
+resource "xenorchestra_vm" "node" {
+    //...
+    affinity_host = data.xenorchestra_host.ng6.id
+    //...
+}
+
+```
+
+## Argument Reference
+* name_label - (Required) The name of the host you want to look up.
+
+## Attributes Reference
+* id - Id of the host.

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -10,12 +10,14 @@ import (
 var testObjectIndex int = 1
 var accTestPrefix string = "terraform-acc"
 var accTestPool client.Pool
+var accTestHost client.Host
 var accDefaultSr client.StorageRepository
 var testTemplate client.Template
 
 func TestMain(m *testing.M) {
 	client.FindTemplateForTests(&testTemplate)
 	client.FindPoolForTests(&accTestPool)
+	client.FindHostForTests(&accTestHost)
 	client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
 	code := m.Run()
 

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -17,7 +17,7 @@ var testTemplate client.Template
 func TestMain(m *testing.M) {
 	client.FindTemplateForTests(&testTemplate)
 	client.FindPoolForTests(&accTestPool)
-	client.FindHostForTests(&accTestHost)
+	client.FindHostForTests(accTestPool.Master, &accTestHost)
 	client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
 	code := m.Run()
 

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -1,6 +1,8 @@
 package xoa
 
 import (
+	"errors"
+	"fmt"
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -21,13 +23,18 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	c := m.(*client.Client)
 	nameLabel := d.Get("name_label").(string)
 	hosts, err := c.GetHostByName(nameLabel)
-	if err != nil {
-		return err
-	}
 
 	if _, ok := err.(client.NotFound); ok {
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+	l := len(hosts)
+	if l != 1 {
+		return errors.New(fmt.Sprintf("found `%d` hosts with name_label `%s`. Hosts must be uniquely named to use this data source", l, nameLabel))
 	}
 
 	d.SetId(hosts[0].Id)

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -1,0 +1,36 @@
+package xoa
+
+import (
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceXoaHost() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHostRead,
+		Schema: map[string]*schema.Schema{
+			"name_label": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*client.Client)
+	nameLabel := d.Get("name_label").(string)
+	hosts, err := c.GetHostByName(nameLabel)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := err.(client.NotFound); ok {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(hosts[0].Id)
+
+	return nil
+}

--- a/xoa/data_source_host_test.go
+++ b/xoa/data_source_host_test.go
@@ -20,7 +20,7 @@ func TestAccXenorchestraDataSource_host(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceHost(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "name_label", accTestPool.NameLabel)),
+					resource.TestCheckResourceAttr(resourceName, "name_label", accTestHost.NameLabel)),
 			},
 		},
 	},
@@ -47,5 +47,5 @@ func testAccXenorchestraDataSourceHostConfig() string {
 data "xenorchestra_host" "host1" {
     name_label = "%s"
 }
-`, accTestPool.NameLabel)
+`, accTestHost.NameLabel)
 }

--- a/xoa/data_source_host_test.go
+++ b/xoa/data_source_host_test.go
@@ -44,7 +44,7 @@ func testAccCheckXenorchestraDataSourceHost(n string) resource.TestCheckFunc {
 
 func testAccXenorchestraDataSourceHostConfig() string {
 	return fmt.Sprintf(`
-data "xenorchestra_host" "host1" {
+data "xenorchestra_host" "host" {
     name_label = "%s"
 }
 `, accTestHost.NameLabel)

--- a/xoa/data_source_host_test.go
+++ b/xoa/data_source_host_test.go
@@ -1,0 +1,51 @@
+package xoa
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccXenorchestraDataSource_host(t *testing.T) {
+	resourceName := "data.xenorchestra_host.host"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccXenorchestraDataSourceHostConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckXenorchestraDataSourceHost(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name_label", accTestPool.NameLabel)),
+			},
+		},
+	},
+	)
+}
+
+func testAccCheckXenorchestraDataSourceHost(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Host data source: %s", n)
+		}
+
+		log.Printf("[DEBUG] Found resource again %v", s.RootModule().Resources)
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Host data source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccXenorchestraDataSourceHostConfig() string {
+	return fmt.Sprintf(`
+data "xenorchestra_host" "host1" {
+    name_label = "%s"
+}
+`, accTestPool.NameLabel)
+}

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -46,6 +46,7 @@ func Provider() terraform.ResourceProvider {
 			"xenorchestra_network":      dataSourceXoaNetwork(),
 			"xenorchestra_pif":          dataSourceXoaPIF(),
 			"xenorchestra_pool":         dataSourceXoaPool(),
+			"xenorchestra_host":         dataSourceXoaHost(),
 			"xenorchestra_template":     dataSourceXoaTemplate(),
 			"xenorchestra_resource_set": dataSourceXoaResourceSet(),
 			"xenorchestra_sr":           dataSourceXoaStorageRepository(),


### PR DESCRIPTION

This PR adds a host data source. refers to #109. 

Get host by name:


```tf
data "xenorchestra_host" "host1" {
  name_label = "xcp-host1-k8s.domain.eu"
}

output "xenorchestra_host" {
  value = data.xenorchestra_host.host1
}
```

Note: **the source branch should be `add-host-data-source`.**