### PR TITLE
Implement creating a VM if a suitable VM isn't found for client acceptance testing

### DIFF
--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	FindHostForTests(accTestPool.Master, &accTestHost)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
 	CreateNetwork(&accDefaultNetwork)
-	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, testTemplate.Id, integrationTestPrefix)
+	FindOrCreateVmForTests(&accVm, accTestPool.Id, accDefaultSr.Id, testTemplate.Id, integrationTestPrefix)
 	CreateResourceSet(testResourceSet)
 
 	code := m.Run()

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	FindHostForTests(accTestPool.Master, &accTestHost)
 	FindStorageRepositoryForTests(accTestPool, &accDefaultSr, integrationTestPrefix)
 	CreateNetwork(&accDefaultNetwork)
-	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, accDefaultNetwork.Id, testTemplate.Id, integrationTestPrefix)
+	FindOrCreateVmForTests(&accVm, accDefaultSr.Id, testTemplate.Id, integrationTestPrefix)
 	CreateResourceSet(testResourceSet)
 
 	code := m.Run()

--- a/client/vm.go
+++ b/client/vm.go
@@ -279,7 +279,7 @@ func (c *Client) waitForModifyVm(id string, waitForIp bool, timeout time.Duratio
 	}
 }
 
-func FindOrCreateVmForTests(vm *Vm, srId, templateName, tag string) {
+func FindOrCreateVmForTests(vm *Vm, poolId, srId, templateName, tag string) {
 	c, err := NewClient(GetConfigFromEnv())
 	if err != nil {
 		fmt.Printf("failed to create client with error: %v\n", err)
@@ -296,7 +296,7 @@ func FindOrCreateVmForTests(vm *Vm, srId, templateName, tag string) {
 		net, err = c.GetNetwork(Network{
 			// TODO: Change this to something that is more stable
 			NameLabel: "Pool-wide network associated with eth0",
-			PoolId:    accTestPool.Id,
+			PoolId:    poolId,
 		})
 
 		if err != nil {

--- a/client/vm.go
+++ b/client/vm.go
@@ -294,7 +294,10 @@ func FindOrCreateVmForTests(vm *Vm, poolId, srId, templateName, tag string) {
 
 	if _, ok := err.(NotFound); ok {
 		net, err = c.GetNetwork(Network{
-			// TODO: Change this to something that is more stable
+			// We assume that a eth0 pool wide network exists
+			// since trying to discern what the appropriate network
+			// is from our current set of test inputs is challenging.
+			// If this proves problematic then it can be reconsidered.
 			NameLabel: "Pool-wide network associated with eth0",
 			PoolId:    poolId,
 		})


### PR DESCRIPTION
This addresses #90.

## Todo
- [ ] ~Do not hard code the network name for the created Vm~ After reconsidering this more, I think this is an acceptable solution for now

## Testing
- [x] Deleted Vm that previously existing with the `xenorchestra-client-` tag and ran the test suite twice to ensure that a Vm was created and then reused on the second test run