### PR TITLE
Add delete timeout (default of 5 mins) and ensure that the create timeout is configurable by the timeouts block

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -86,7 +86,7 @@ func (v Vm) Compare(obj interface{}) bool {
 	return false
 }
 
-func (c *Client) CreateVm(vmReq Vm) (*Vm, error) {
+func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	tmpl, err := c.GetTemplate(Template{
 		Id: vmReq.Template,
 	})
@@ -169,7 +169,7 @@ func (c *Client) CreateVm(vmReq Vm) (*Vm, error) {
 		return nil, err
 	}
 
-	err = c.waitForModifyVm(vmId, vmReq.WaitForIps, 5*time.Minute)
+	err = c.waitForModifyVm(vmId, vmReq.WaitForIps, createTime)
 
 	if err != nil {
 		return nil, err
@@ -395,6 +395,7 @@ func FindOrCreateVmForTests(vm *Vm, poolId, srId, templateName, tag string) {
 					},
 				},
 			},
+			5*time.Minute,
 		)
 	}
 

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -35,6 +35,7 @@ func resourceRecord() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: &duration,
 			Update: &duration,
+			Delete: &duration,
 		},
 		Schema: map[string]*schema.Schema{
 			"affinity_host": &schema.Schema{
@@ -314,6 +315,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		VIFsMap:      network_maps,
 		WaitForIps:   d.Get("wait_for_ip").(bool),
 	},
+		d.Timeout(schema.TimeoutCreate),
 	)
 
 	if err != nil {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -315,6 +315,20 @@ func Test_shouldUpdateVif(t *testing.T) {
 	}
 }
 
+func TestAccXenorchestraVm_createWithShorterResourceTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVmConfigWithShortTimeout(),
+				ExpectError: regexp.MustCompile("timeout while waiting for state to become"),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_createAndPlanWithNonExistantVm(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	removeVm := func() {
@@ -1355,6 +1369,41 @@ resource "xenorchestra_vm" "bar" {
       sr_id = "%s"
       name_label = "disk 1"
       size = 10001317888
+    }
+}
+`, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)
+}
+
+func testAccVmConfigWithShortTimeout() string {
+	return testAccCloudConfigConfig("vm-template", "template") + fmt.Sprintf(`
+data "xenorchestra_template" "template" {
+    name_label = "%s"
+}
+
+data "xenorchestra_network" "network" {
+    name_label = "Pool-wide network associated with eth0"
+    pool_id = "%s"
+}
+
+resource "xenorchestra_vm" "bar" {
+    memory_max = 4295000000
+    cpus  = 1
+    cloud_config = "${xenorchestra_cloud_config.bar.template}"
+    name_label = "Terraform testing"
+    name_description = "description"
+    template = "${data.xenorchestra_template.template.id}"
+    network {
+	network_id = "${data.xenorchestra_network.network.id}"
+    }
+
+    disk {
+      sr_id = "%s"
+      name_label = "disk 1"
+      size = 10001317888
+    }
+
+    timeouts {
+	create = "5s"
     }
 }
 `, testTemplate.NameLabel, accTestPool.Id, accDefaultSr.Id)


### PR DESCRIPTION
This addresses #134.

## Todo
- [x] New test passes
- [ ] ~Ensure that vm from the acceptance test is cleaned up~ Will follow up in #84 
- [x] `make testacc` passes

This change only needed to pass the create timeout through to the client code because that is the only piece that polls the Vm and takes action if it doesn't transition into the desired state.