### PR TITLE
Add support for terraformer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ TF_LOG=debug TEST=TestAccXONetworkDataSource_read make testacc
 The following command can be used to run the entire test suite.
 
 ```
-make testacc
+# This runs the testclient and testacc Makefile targets
+make test
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: import testacc dist
+.PHONY: import testacc testclient test dist
 
 TIMEOUT ?= 40m
 ifdef TEST
@@ -26,6 +26,11 @@ plan: build
 
 apply:
 	terraform apply
+
+test: testclient testacc
+
+testclient:
+	cd client; go test $(TEST) -v -count 1
 
 testacc:
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)

--- a/client/acl.go
+++ b/client/acl.go
@@ -42,7 +42,7 @@ func (c *Client) CreateAcl(acl Acl) (*Acl, error) {
 	return c.GetAcl(acl)
 }
 
-func (c *Client) GetAcl(aclReq Acl) (*Acl, error) {
+func (c *Client) GetAcls() ([]Acl, error) {
 	params := map[string]interface{}{
 		"dummy": "dummy",
 	}
@@ -53,6 +53,14 @@ func (c *Client) GetAcl(aclReq Acl) (*Acl, error) {
 		return nil, err
 	}
 	log.Printf("[DEBUG] Found the following ACLs: %v\n", acls)
+	return acls, nil
+}
+
+func (c *Client) GetAcl(aclReq Acl) (*Acl, error) {
+	acls, err := c.GetAcls()
+	if err != nil {
+		return nil, err
+	}
 
 	var foundAcl Acl
 	for _, acl := range acls {

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,0 +1,8 @@
+module github.com/ddelnano/terraform-provider-xenorchestra/client
+
+go 1.14
+
+require (
+	github.com/gorilla/websocket v1.4.2
+	github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750
+)

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,0 +1,5 @@
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750 h1:j3HKQAXXj5vV3oHyg9pjK3uIM4bidukvv+tR2iJCvFA=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=

--- a/client/state.go
+++ b/client/state.go
@@ -1,0 +1,343 @@
+package client
+
+// This file is copied from the
+// github.com/hashicorp/terraform-plugin-sdk/helper/resource
+// package. In order for this client to work with github.com/GoogleCloudPlatform/terraformer
+// the terraform sdk cannot be used otherwise some package initialization code causes a runtime crash.
+// See https://github.com/ddelnano/terraformer/commit/03999bce04c47c95957b2d569307c3ab9e80763f#comments
+// for more details.
+
+// Ideally the xenorchestra client code would be completely decoupled from terraform and so this approach
+// will likely need to be reconsidered
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+)
+
+var refreshGracePeriod = 30 * time.Second
+
+// StateRefreshFunc is a function type used for StateChangeConf that is
+// responsible for refreshing the item being watched for a state change.
+//
+// It returns three results. `result` is any object that will be returned
+// as the final object after waiting for state change. This allows you to
+// return the final updated object, for example an EC2 instance after refreshing
+// it.
+//
+// `state` is the latest state of that object. And `err` is any error that
+// may have happened while refreshing the state.
+type StateRefreshFunc func() (result interface{}, state string, err error)
+
+// StateChangeConf is the configuration struct used for `WaitForState`.
+type StateChangeConf struct {
+	Delay          time.Duration    // Wait this time before starting checks
+	Pending        []string         // States that are "allowed" and will continue trying
+	Refresh        StateRefreshFunc // Refreshes the current state
+	Target         []string         // Target state
+	Timeout        time.Duration    // The amount of time to wait before timeout
+	MinTimeout     time.Duration    // Smallest time to wait before refreshes
+	PollInterval   time.Duration    // Override MinTimeout/backoff and only poll this often
+	NotFoundChecks int              // Number of times to allow not found
+
+	// This is to work around inconsistent APIs
+	ContinuousTargetOccurence int // Number of times the Target state has to occur continuously
+}
+
+// WaitForState watches an object and waits for it to achieve the state
+// specified in the configuration using the specified Refresh() func,
+// waiting the number of seconds specified in the timeout configuration.
+//
+// If the Refresh function returns an error, exit immediately with that error.
+//
+// If the Refresh function returns a state other than the Target state or one
+// listed in Pending, return immediately with an error.
+//
+// If the Timeout is exceeded before reaching the Target state, return an
+// error.
+//
+// Otherwise, the result is the result of the first call to the Refresh function to
+// reach the target state.
+func (conf *StateChangeConf) WaitForState() (interface{}, error) {
+	log.Printf("[DEBUG] Waiting for state to become: %s", conf.Target)
+
+	notfoundTick := 0
+	targetOccurence := 0
+
+	// Set a default for times to check for not found
+	if conf.NotFoundChecks == 0 {
+		conf.NotFoundChecks = 20
+	}
+
+	if conf.ContinuousTargetOccurence == 0 {
+		conf.ContinuousTargetOccurence = 1
+	}
+
+	type Result struct {
+		Result interface{}
+		State  string
+		Error  error
+		Done   bool
+	}
+
+	// Read every result from the refresh loop, waiting for a positive result.Done.
+	resCh := make(chan Result, 1)
+	// cancellation channel for the refresh loop
+	cancelCh := make(chan struct{})
+
+	result := Result{}
+
+	go func() {
+		defer close(resCh)
+
+		time.Sleep(conf.Delay)
+
+		// start with 0 delay for the first loop
+		var wait time.Duration
+
+		for {
+			// store the last result
+			resCh <- result
+
+			// wait and watch for cancellation
+			select {
+			case <-cancelCh:
+				return
+			case <-time.After(wait):
+				// first round had no wait
+				if wait == 0 {
+					wait = 100 * time.Millisecond
+				}
+			}
+
+			res, currentState, err := conf.Refresh()
+			result = Result{
+				Result: res,
+				State:  currentState,
+				Error:  err,
+			}
+
+			if err != nil {
+				resCh <- result
+				return
+			}
+
+			// If we're waiting for the absence of a thing, then return
+			if res == nil && len(conf.Target) == 0 {
+				targetOccurence++
+				if conf.ContinuousTargetOccurence == targetOccurence {
+					result.Done = true
+					resCh <- result
+					return
+				}
+				continue
+			}
+
+			if res == nil {
+				// If we didn't find the resource, check if we have been
+				// not finding it for awhile, and if so, report an error.
+				notfoundTick++
+				if notfoundTick > conf.NotFoundChecks {
+					result.Error = &NotFoundError{
+						LastError: err,
+						Retries:   notfoundTick,
+					}
+					resCh <- result
+					return
+				}
+			} else {
+				// Reset the counter for when a resource isn't found
+				notfoundTick = 0
+				found := false
+
+				for _, allowed := range conf.Target {
+					if currentState == allowed {
+						found = true
+						targetOccurence++
+						if conf.ContinuousTargetOccurence == targetOccurence {
+							result.Done = true
+							resCh <- result
+							return
+						}
+						continue
+					}
+				}
+
+				for _, allowed := range conf.Pending {
+					if currentState == allowed {
+						found = true
+						targetOccurence = 0
+						break
+					}
+				}
+
+				if !found && len(conf.Pending) > 0 {
+					result.Error = &UnexpectedStateError{
+						LastError:     err,
+						State:         result.State,
+						ExpectedState: conf.Target,
+					}
+					resCh <- result
+					return
+				}
+			}
+
+			// Wait between refreshes using exponential backoff, except when
+			// waiting for the target state to reoccur.
+			if targetOccurence == 0 {
+				wait *= 2
+			}
+
+			// If a poll interval has been specified, choose that interval.
+			// Otherwise bound the default value.
+			if conf.PollInterval > 0 && conf.PollInterval < 180*time.Second {
+				wait = conf.PollInterval
+			} else {
+				if wait < conf.MinTimeout {
+					wait = conf.MinTimeout
+				} else if wait > 10*time.Second {
+					wait = 10 * time.Second
+				}
+			}
+
+			log.Printf("[TRACE] Waiting %s before next try", wait)
+		}
+	}()
+
+	// store the last value result from the refresh loop
+	lastResult := Result{}
+
+	timeout := time.After(conf.Timeout)
+	for {
+		select {
+		case r, ok := <-resCh:
+			// channel closed, so return the last result
+			if !ok {
+				return lastResult.Result, lastResult.Error
+			}
+
+			// we reached the intended state
+			if r.Done {
+				return r.Result, r.Error
+			}
+
+			// still waiting, store the last result
+			lastResult = r
+
+		case <-timeout:
+			log.Printf("[WARN] WaitForState timeout after %s", conf.Timeout)
+			log.Printf("[WARN] WaitForState starting %s refresh grace period", refreshGracePeriod)
+
+			// cancel the goroutine and start our grace period timer
+			close(cancelCh)
+			timeout := time.After(refreshGracePeriod)
+
+			// we need a for loop and a label to break on, because we may have
+			// an extra response value to read, but still want to wait for the
+			// channel to close.
+		forSelect:
+			for {
+				select {
+				case r, ok := <-resCh:
+					if r.Done {
+						// the last refresh loop reached the desired state
+						return r.Result, r.Error
+					}
+
+					if !ok {
+						// the goroutine returned
+						break forSelect
+					}
+
+					// target state not reached, save the result for the
+					// TimeoutError and wait for the channel to close
+					lastResult = r
+				case <-timeout:
+					log.Println("[ERROR] WaitForState exceeded refresh grace period")
+					break forSelect
+				}
+			}
+
+			return nil, &TimeoutError{
+				LastError:     lastResult.Error,
+				LastState:     lastResult.State,
+				Timeout:       conf.Timeout,
+				ExpectedState: conf.Target,
+			}
+		}
+	}
+}
+
+type NotFoundError struct {
+	LastError    error
+	LastRequest  interface{}
+	LastResponse interface{}
+	Message      string
+	Retries      int
+}
+
+func (e *NotFoundError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	if e.Retries > 0 {
+		return fmt.Sprintf("couldn't find resource (%d retries)", e.Retries)
+	}
+
+	return "couldn't find resource"
+}
+
+// UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
+type UnexpectedStateError struct {
+	LastError     error
+	State         string
+	ExpectedState []string
+}
+
+func (e *UnexpectedStateError) Error() string {
+	return fmt.Sprintf(
+		"unexpected state '%s', wanted target '%s'. last error: %s",
+		e.State,
+		strings.Join(e.ExpectedState, ", "),
+		e.LastError,
+	)
+}
+
+// TimeoutError is returned when WaitForState times out
+type TimeoutError struct {
+	LastError     error
+	LastState     string
+	Timeout       time.Duration
+	ExpectedState []string
+}
+
+func (e *TimeoutError) Error() string {
+	expectedState := "resource to be gone"
+	if len(e.ExpectedState) > 0 {
+		expectedState = fmt.Sprintf("state to become '%s'", strings.Join(e.ExpectedState, ", "))
+	}
+
+	extraInfo := make([]string, 0)
+	if e.LastState != "" {
+		extraInfo = append(extraInfo, fmt.Sprintf("last state: '%s'", e.LastState))
+	}
+	if e.Timeout > 0 {
+		extraInfo = append(extraInfo, fmt.Sprintf("timeout: %s", e.Timeout.String()))
+	}
+
+	suffix := ""
+	if len(extraInfo) > 0 {
+		suffix = fmt.Sprintf(" (%s)", strings.Join(extraInfo, ", "))
+	}
+
+	if e.LastError != nil {
+		return fmt.Sprintf("timeout while waiting for %s%s: %s",
+			expectedState, suffix, e.LastError)
+	}
+
+	return fmt.Sprintf("timeout while waiting for %s%s",
+		expectedState, suffix)
+}

--- a/client/vm.go
+++ b/client/vm.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"os"
 	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 type allObjectResponse struct {
@@ -298,7 +296,7 @@ func (c *Client) waitForModifyVm(id string, waitForIp bool, timeout time.Duratio
 
 			return vm, vm.PowerState, nil
 		}
-		stateConf := &resource.StateChangeConf{
+		stateConf := &StateChangeConf{
 			Pending: []string{"Halted", "Stopped"},
 			Refresh: refreshFn,
 			Target:  []string{"Running"},
@@ -321,7 +319,7 @@ func (c *Client) waitForModifyVm(id string, waitForIp bool, timeout time.Duratio
 
 			return vm, "Ready", nil
 		}
-		stateConf := &resource.StateChangeConf{
+		stateConf := &StateChangeConf{
 			Pending: []string{"Waiting"},
 			Refresh: refreshFn,
 			Target:  []string{"Ready"},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/ddelnano/terraform-provider-xenorchestra
 go 1.14
 
 require (
-	github.com/gorilla/websocket v1.4.0
+	github.com/ddelnano/terraform-provider-xenorchestra/client v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
-	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 )
+
+replace github.com/ddelnano/terraform-provider-xenorchestra/client => ./client

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,9 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
@@ -184,8 +185,8 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a h1:jTZwOlrDhmk4Ez2vhWh7kA0eKUahp1lCO2uyM4fi/Qk=
-github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a/go.mod h1:eESpbCslcLDs8j2D7IEdGVgul7xuk9odqDTaor30IUU=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750 h1:j3HKQAXXj5vV3oHyg9pjK3uIM4bidukvv+tR2iJCvFA=
+github.com/sourcegraph/jsonrpc2 v0.0.0-20210201082850-366fbb520750/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
This PR implements basic support for [GoogleCloudPlatform/terraformer](https://github.com/GoogleCloudPlatform/terraformer) - #96

It migrates the `github.com/ddelnano/terraform-provider-xenorchestra/client` package into its own go module so that terraformer can install it without including the terraform-plugin-sdk (which causes runtime crashes like [this](https://github.com/ddelnano/terraformer/commit/03999bce04c47c95957b2d569307c3ab9e80763f#comments) when imported multiple times).

In addition to that it will support the `acl` and `resource_set` resources with terraformer to start

## Testing
- [x] `make test` passes