### PR TITLE
extend host data source variables

### DIFF
--- a/client/host.go
+++ b/client/host.go
@@ -8,10 +8,17 @@ import (
 )
 
 type Host struct {
-	Id        string        `json:"id"`
-	NameLabel string        `json:"name_label"`
-	Tags      []interface{} `json:"tags,omitempty"`
-	Pool      string        `json:"$pool"`
+	Id        string           `json:"id"`
+	NameLabel string           `json:"name_label"`
+	Tags      []interface{}    `json:"tags,omitempty"`
+	Pool      string           `json:"$pool"`
+	Memory    HostMemoryObject `json:"memory"`
+	Cpus      CpuInfo          `json:"cpus"`
+}
+
+type HostMemoryObject struct {
+	Usage int `json:"usage"`
+	Size  int `json:"size"`
 }
 
 func (h Host) Compare(obj interface{}) bool {

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -24,4 +24,10 @@ Terraform will fail. Ensure that your names are unique when
 using the data source.
 
 ## Attributes Reference
-* id - Id of the host.
+* id - The id of the host.
+* name_label - Name label of the host.
+* pool_id - Id of the pool that the host belongs to.
+* tags - The tags applied to the host.
+* cpus - Host cpu information.
+    * cores - The number of cores.
+    * sockets - The number of sockets.

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -28,6 +28,8 @@ using the data source.
 * name_label - Name label of the host.
 * pool_id - Id of the pool that the host belongs to.
 * tags - The tags applied to the host.
+* memory - The memory size for the host.
+* memory_usage - The memory usage for the host.
 * cpus - Host cpu information.
     * cores - The number of cores.
     * sockets - The number of sockets.

--- a/docs/data-sources/hosts.md
+++ b/docs/data-sources/hosts.md
@@ -36,7 +36,10 @@ resource "xenorchestra_vm" "vm" {
 ## Attributes Reference
 * master - The primary host of the pool
 * hosts - List containing the matching hosts after applying the argument filtering. 
-  * id - The id of the host
-  * name_label - Name label of the host 
-  * pool_id - Id of the pool that the host belongs to
-  * tags - The tags applied to the host
+  * id - The id of the host.
+  * name_label - Name label of the host.
+  * pool_id - Id of the pool that the host belongs to.
+  * tags - The tags applied to the host.
+  * cpus - Host cpu information.
+    * cores - The number of cores. 
+    * sockets - The number of sockets.

--- a/docs/data-sources/hosts.md
+++ b/docs/data-sources/hosts.md
@@ -40,6 +40,8 @@ resource "xenorchestra_vm" "vm" {
   * name_label - Name label of the host.
   * pool_id - Id of the pool that the host belongs to.
   * tags - The tags applied to the host.
+  * memory - The memory size for the host.
+  * memory_usage - The memory usage for the host.
   * cpus - Host cpu information.
     * cores - The number of cores. 
     * sockets - The number of sockets.

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -42,10 +42,13 @@ func resourceHostSchema() map[string]*schema.Schema {
 		"cpus": &schema.Schema{
 			Type:     schema.TypeMap,
 			Computed: true,
-			Required: false,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"memory": &schema.Schema{
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"memory_usage": &schema.Schema{
 			Type:     schema.TypeInt,
 			Computed: true,
 		},
@@ -67,6 +70,23 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(hosts[0].Id)
-
+	d.Set("pool_id", hosts[0].Pool)
+	d.Set("memory", hosts[0].Memory.Size)
+	d.Set("memory_usage", hosts[0].Memory.Usage)
+	d.Set("cpus", cpusToMapList(hosts)[0])
+	d.Set("tags", hosts[0].Tags)
 	return nil
+}
+
+func cpusToMapList(hosts []client.Host) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(hosts))
+	for _, host := range hosts {
+		cpus := map[string]interface{}{
+			"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
+			"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
+		}
+		result = append(result, cpus)
+	}
+
+	return result
 }

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -39,6 +39,16 @@ func resourceHostSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"cpus": &schema.Schema{
+			Type:     schema.TypeMap,
+			Computed: true,
+			Required: false,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"memory": &schema.Schema{
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
 		"tags": resourceTags(),
 	}
 }

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -73,12 +73,12 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("pool_id", hosts[0].Pool)
 	d.Set("memory", hosts[0].Memory.Size)
 	d.Set("memory_usage", hosts[0].Memory.Usage)
-	d.Set("cpus", cpusToMapList(hosts)[0])
+	d.Set("cpus", hostCpuInfoToMapList(hosts)[0])
 	d.Set("tags", hosts[0].Tags)
 	return nil
 }
 
-func cpusToMapList(hosts []client.Host) []map[string]interface{} {
+func hostCpuInfoToMapList(hosts []client.Host) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(hosts))
 	for _, host := range hosts {
 		cpus := map[string]interface{}{

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -78,10 +78,9 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func hostCpuInfoToMapList(host client.Host) map[string]interface{} {
-	cpus := map[string]interface{}{
+func hostCpuInfoToMapList(host client.Host) map[string]string {
+	return map[string]string{
 		"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
 		"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
 	}
-	return cpus
 }

--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -73,20 +73,15 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("pool_id", hosts[0].Pool)
 	d.Set("memory", hosts[0].Memory.Size)
 	d.Set("memory_usage", hosts[0].Memory.Usage)
-	d.Set("cpus", hostCpuInfoToMapList(hosts)[0])
+	d.Set("cpus", hostCpuInfoToMapList(hosts[0]))
 	d.Set("tags", hosts[0].Tags)
 	return nil
 }
 
-func hostCpuInfoToMapList(hosts []client.Host) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(hosts))
-	for _, host := range hosts {
-		cpus := map[string]interface{}{
-			"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
-			"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
-		}
-		result = append(result, cpus)
+func hostCpuInfoToMapList(host client.Host) map[string]interface{} {
+	cpus := map[string]interface{}{
+		"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
+		"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
 	}
-
-	return result
+	return cpus
 }

--- a/xoa/data_source_host_test.go
+++ b/xoa/data_source_host_test.go
@@ -21,6 +21,10 @@ func TestAccXenorchestraDataSource_host(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceHost(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cpus.cores"),
+					resource.TestCheckResourceAttrSet(resourceName, "cpus.sockets"),
+					resource.TestCheckResourceAttrSet(resourceName, "memory"),
+					resource.TestCheckResourceAttrSet(resourceName, "memory_usage"),
 					resource.TestCheckResourceAttr(resourceName, "name_label", accTestHost.NameLabel)),
 			},
 		},

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -78,12 +78,13 @@ func hostsToMapList(hosts []client.Host) []map[string]interface{} {
 			"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
 		}
 		hostMap := map[string]interface{}{
-			"id":         host.Id,
-			"name_label": host.NameLabel,
-			"pool_id":    host.Pool,
-			"tags":       host.Tags,
-			"memory":     host.Memory.Size,
-			"cpus":       cpus,
+			"id":           host.Id,
+			"name_label":   host.NameLabel,
+			"pool_id":      host.Pool,
+			"tags":         host.Tags,
+			"memory":       host.Memory.Size,
+			"memory_usage": host.Memory.Usage,
+			"cpus":         cpus,
 		}
 		result = append(result, hostMap)
 	}

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -1,7 +1,6 @@
 package xoa
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
@@ -71,10 +70,6 @@ func dataSourceHostsRead(d *schema.ResourceData, m interface{}) error {
 func hostsToMapList(hosts []client.Host) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(hosts))
 	for _, host := range hosts {
-		cpus := map[string]string{
-			"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
-			"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
-		}
 		hostMap := map[string]interface{}{
 			"id":           host.Id,
 			"name_label":   host.NameLabel,
@@ -82,7 +77,7 @@ func hostsToMapList(hosts []client.Host) []map[string]interface{} {
 			"tags":         host.Tags,
 			"memory":       host.Memory.Size,
 			"memory_usage": host.Memory.Usage,
-			"cpus":         cpus,
+			"cpus":         hostCpuInfoToMapList(host),
 		}
 		result = append(result, hostMap)
 	}

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -1,6 +1,7 @@
 package xoa
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
@@ -46,7 +47,12 @@ func dataSourceHostsRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	hosts, err := c.GetSortedHosts(client.Host{Pool: pool[0].Id, Tags: tags}, d.Get("sort_by").(string), d.Get("sort_order").(string))
+	searchHost := client.Host{
+		Pool:   pool[0].Id,
+		Tags:   tags,
+		Cpus:   client.CpuInfo{},
+		Memory: client.HostMemoryObject{}}
+	hosts, err := c.GetSortedHosts(searchHost, d.Get("sort_by").(string), d.Get("sort_order").(string))
 
 	log.Printf("[DEBUG] found the following hosts: %s", hosts)
 	if err != nil {
@@ -67,11 +73,17 @@ func dataSourceHostsRead(d *schema.ResourceData, m interface{}) error {
 func hostsToMapList(hosts []client.Host) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(hosts))
 	for _, host := range hosts {
+		cpus := map[string]string{
+			"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
+			"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
+		}
 		hostMap := map[string]interface{}{
 			"id":         host.Id,
 			"name_label": host.NameLabel,
 			"pool_id":    host.Pool,
 			"tags":       host.Tags,
+			"memory":     host.Memory.Size,
+			"cpus":       cpus,
 		}
 		result = append(result, hostMap)
 	}

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -54,7 +54,7 @@ func dataSourceHostsRead(d *schema.ResourceData, m interface{}) error {
 		Memory: client.HostMemoryObject{}}
 	hosts, err := c.GetSortedHosts(searchHost, d.Get("sort_by").(string), d.Get("sort_order").(string))
 
-	log.Printf("[DEBUG] found the following hosts: %s", hosts)
+	log.Printf("[DEBUG] found the following hosts: %+v", hosts)
 	if err != nil {
 		return err
 	}

--- a/xoa/data_source_hosts.go
+++ b/xoa/data_source_hosts.go
@@ -48,10 +48,8 @@ func dataSourceHostsRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	searchHost := client.Host{
-		Pool:   pool[0].Id,
-		Tags:   tags,
-		Cpus:   client.CpuInfo{},
-		Memory: client.HostMemoryObject{}}
+		Pool: pool[0].Id,
+		Tags: tags}
 	hosts, err := c.GetSortedHosts(searchHost, d.Get("sort_by").(string), d.Get("sort_order").(string))
 
 	log.Printf("[DEBUG] found the following hosts: %+v", hosts)

--- a/xoa/data_source_hosts_test.go
+++ b/xoa/data_source_hosts_test.go
@@ -76,6 +76,8 @@ func getCompositeAggregateTestFunc(resourceName, sortBy, sortOrder string) resou
 	return resource.ComposeAggregateTestCheckFunc(
 		testAccCheckXenorchestraDataSourceHosts(resourceName),
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.cpus.sockets"),
+		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.memory"),
 		resource.TestCheckResourceAttr(resourceName, "pool_id", accTestPool.Id),
 		// Verify that there are atleast 2 hosts returned
 		// This is necessary to test the sorting logic

--- a/xoa/data_source_hosts_test.go
+++ b/xoa/data_source_hosts_test.go
@@ -76,8 +76,10 @@ func getCompositeAggregateTestFunc(resourceName, sortBy, sortOrder string) resou
 	return resource.ComposeAggregateTestCheckFunc(
 		testAccCheckXenorchestraDataSourceHosts(resourceName),
 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.cpus.cores"),
 		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.cpus.sockets"),
 		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.memory"),
+		resource.TestCheckResourceAttrSet(resourceName, "hosts.0.memory_usage"),
 		resource.TestCheckResourceAttr(resourceName, "pool_id", accTestPool.Id),
 		// Verify that there are atleast 2 hosts returned
 		// This is necessary to test the sorting logic


### PR DESCRIPTION
In preparation to the vms data source, I've extended the variables from host data sources to include cpu and memory information. 

I was not able to wrap the memory info into a map like done with cpu info in `hostCpuInfoToMapList()` function. Therefore, i added `memory` and `memory_usage` as own variables.  


