### PR TITLE
Update hosts cpu type to integer

### DIFF
--- a/xoa/data_source_host.go
+++ b/xoa/data_source_host.go
@@ -42,7 +42,7 @@ func resourceHostSchema() map[string]*schema.Schema {
 		"cpus": &schema.Schema{
 			Type:     schema.TypeMap,
 			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem:     &schema.Schema{Type: schema.TypeInt},
 		},
 		"memory": &schema.Schema{
 			Type:     schema.TypeInt,
@@ -78,9 +78,9 @@ func dataSourceHostRead(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func hostCpuInfoToMapList(host client.Host) map[string]string {
-	return map[string]string{
-		"sockets": fmt.Sprintf("%d", host.Cpus.Sockets),
-		"cores":   fmt.Sprintf("%d", host.Cpus.Cores),
+func hostCpuInfoToMapList(host client.Host) map[string]int {
+	return map[string]int{
+		"sockets": int(host.Cpus.Sockets),
+		"cores":   int(host.Cpus.Cores),
 	}
 }


### PR DESCRIPTION
Did find a little issue when testing #160 in combination with #161. The number of Host CPU and Sockets was mapped to a string instead of integer.

This is inconsistent, since vm's CPU information is returned as an integer as well. 
It also makes unwanted type casting necessary, when processing vm and host CPU values. 

Sorry, I already noticed this before merging #160, and thought I mentioned it. Seems like my brain tricked me.

@ddelnano what do you think about these changes? 