### PR TITLE
Add vms data source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
 ifdef TEST
-    TEST := ./... -run $(TEST)
+    TEST := ./... -run '$(TEST)'
 else
     TEST := ./...
 endif

--- a/client/client.go
+++ b/client/client.go
@@ -28,7 +28,7 @@ type XOClient interface {
 
 	CreateVm(vmReq Vm, d time.Duration) (*Vm, error)
 	GetVm(vmReq Vm) (*Vm, error)
-	GetVms() ([]Vm, error)
+	GetVms(vm Vm) ([]Vm, error)
 	UpdateVm(vmReq Vm) (*Vm, error)
 	DeleteVm(id string) error
 	HaltVm(vmReq Vm) error
@@ -215,7 +215,7 @@ type XoObject interface {
 	Compare(obj interface{}) bool
 }
 
-func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
+func (c *Client) getObjectTypeFilter(obj XoObject) map[string]interface{} {
 	xoApiType := ""
 	switch t := obj.(type) {
 	case Network:
@@ -241,12 +241,15 @@ func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
 	default:
 		panic(fmt.Sprintf("XO client does not support type: %T", t))
 	}
-	params := map[string]interface{}{
+	return map[string]interface{}{
 		"filter": map[string]string{
 			"type": xoApiType,
 		},
 	}
-	return c.Call("xo.getAllObjects", params, response)
+}
+
+func (c *Client) GetAllObjectsOfType(obj XoObject, response interface{}) error {
+	return c.Call("xo.getAllObjects", c.getObjectTypeFilter(obj), response)
 }
 
 func (c *Client) FindFromGetAllObjects(obj XoObject) (interface{}, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -28,6 +28,7 @@ type XOClient interface {
 
 	CreateVm(vmReq Vm, d time.Duration) (*Vm, error)
 	GetVm(vmReq Vm) (*Vm, error)
+	GetVms() ([]Vm, error)
 	UpdateVm(vmReq Vm) (*Vm, error)
 	DeleteVm(id string) error
 	HaltVm(vmReq Vm) error

--- a/client/vm.go
+++ b/client/vm.go
@@ -69,10 +69,14 @@ func (v Vm) Compare(obj interface{}) bool {
 	if v.NameLabel != "" && v.NameLabel == other.NameLabel {
 		return true
 	}
-	if v.PowerState != "" && v.PowerState == other.PowerState {
+	if v.PowerState != "" && v.Container != "" {
+		if (v.PowerState == other.PowerState) && (v.Container == other.Container) {
+			return true
+		}
+		return false
+	} else if v.PowerState != "" && v.PowerState == other.PowerState {
 		return true
-	}
-	if v.Container != "" && v.Container == other.Container {
+	} else if v.Container != "" && v.Container == other.Container {
 		return true
 	}
 	tagCount := len(v.Tags)

--- a/client/vm.go
+++ b/client/vm.go
@@ -43,7 +43,7 @@ type Vm struct {
 	CloudConfig        string            `json:"cloudConfig"`
 	ResourceSet        string            `json:"resourceSet,omitempty"`
 	Tags               []string          `json:"tags"`
-	Container          string            `json:"$container"`
+	Host               string            `json:"$container"`
 
 	// These fields are used for passing in disk inputs when
 	// creating Vms, however, this is not a real field as far
@@ -69,14 +69,14 @@ func (v Vm) Compare(obj interface{}) bool {
 	if v.NameLabel != "" && v.NameLabel == other.NameLabel {
 		return true
 	}
-	if v.PowerState != "" && v.Container != "" {
-		if (v.PowerState == other.PowerState) && (v.Container == other.Container) {
+	if v.PowerState != "" && v.Host != "" {
+		if (v.PowerState == other.PowerState) && (v.Host == other.Host) {
 			return true
 		}
 		return false
 	} else if v.PowerState != "" && v.PowerState == other.PowerState {
 		return true
-	} else if v.Container != "" && v.Container == other.Container {
+	} else if v.Host != "" && v.Host == other.Host {
 		return true
 	}
 	tagCount := len(v.Tags)
@@ -305,7 +305,7 @@ func (c *Client) GetVm(vmReq Vm) (*Vm, error) {
 func (c *Client) GetVms(vm Vm) ([]Vm, error) {
 	var vms []Vm
 	var response map[string]Vm
-	if vm.Container == "" && vm.PowerState == "" {
+	if vm.Host == "" && vm.PowerState == "" {
 		err := c.GetAllObjectsOfType(vm, &response)
 
 		if err != nil {

--- a/client/vm.go
+++ b/client/vm.go
@@ -43,6 +43,7 @@ type Vm struct {
 	CloudConfig        string            `json:"cloudConfig"`
 	ResourceSet        string            `json:"resourceSet,omitempty"`
 	Tags               []string          `json:"tags"`
+	Container          string            `json:"$container"`
 
 	// These fields are used for passing in disk inputs when
 	// creating Vms, however, this is not a real field as far
@@ -68,7 +69,12 @@ func (v Vm) Compare(obj interface{}) bool {
 	if v.NameLabel != "" && v.NameLabel == other.NameLabel {
 		return true
 	}
-
+	if v.PowerState != "" && v.PowerState == other.PowerState {
+		return true
+	}
+	if v.Container != "" && v.Container == other.Container {
+		return true
+	}
 	tagCount := len(v.Tags)
 	if tagCount > 0 {
 		for _, tag := range v.Tags {
@@ -292,20 +298,34 @@ func (c *Client) GetVm(vmReq Vm) (*Vm, error) {
 	return &vms[0], nil
 }
 
-func (c *Client) GetVms() ([]Vm, error) {
-
+func (c *Client) GetVms(vm Vm) ([]Vm, error) {
+	var vms []Vm
 	var response map[string]Vm
-	err := c.GetAllObjectsOfType(Vm{PowerState: "Running"}, &response)
+	if vm.Container == "" && vm.PowerState == "" {
+		err := c.GetAllObjectsOfType(vm, &response)
 
-	if err != nil {
-		return []Vm{}, err
+		if err != nil {
+			return []Vm{}, err
+		}
+
+		vms = make([]Vm, 0, len(response))
+		for _, vm := range response {
+			vms = append(vms, vm)
+		}
+
+	} else {
+		obj, err := c.FindFromGetAllObjects(vm)
+
+		if err != nil {
+			return []Vm{}, err
+		}
+		iterator := obj.([]Vm)
+		vms = make([]Vm, 0, len(iterator))
+		for _, vm := range iterator {
+			vms = append(vms, vm)
+		}
+
 	}
-
-	vms := make([]Vm, 0, len(response))
-	for _, vm := range response {
-		vms = append(vms, vm)
-	}
-
 	log.Printf("[DEBUG] Found vms: %+v", vms)
 	return vms, nil
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -79,6 +79,9 @@ func (v Vm) Compare(obj interface{}) bool {
 	} else if v.Host != "" && v.Host == other.Host {
 		return true
 	}
+	if v.PoolId != "" && v.PoolId == other.PoolId {
+		return true
+	}
 	tagCount := len(v.Tags)
 	if tagCount > 0 {
 		for _, tag := range v.Tags {
@@ -303,33 +306,11 @@ func (c *Client) GetVm(vmReq Vm) (*Vm, error) {
 }
 
 func (c *Client) GetVms(vm Vm) ([]Vm, error) {
-	var vms []Vm
-	var response map[string]Vm
-	if vm.Host == "" && vm.PowerState == "" {
-		err := c.GetAllObjectsOfType(vm, &response)
-
-		if err != nil {
-			return []Vm{}, err
-		}
-
-		vms = make([]Vm, 0, len(response))
-		for _, vm := range response {
-			vms = append(vms, vm)
-		}
-
-	} else {
-		obj, err := c.FindFromGetAllObjects(vm)
-
-		if err != nil {
-			return []Vm{}, err
-		}
-		iterator := obj.([]Vm)
-		vms = make([]Vm, 0, len(iterator))
-		for _, vm := range iterator {
-			vms = append(vms, vm)
-		}
-
+	obj, err := c.FindFromGetAllObjects(vm)
+	if err != nil {
+		return []Vm{}, err
 	}
+	vms := obj.([]Vm)
 	log.Printf("[DEBUG] Found vms: %+v", vms)
 	return vms, nil
 }

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -1,6 +1,6 @@
 # xenorchestra_vms
 
-Provides information about VMs
+Use this data source to filter Xenorchestra VMS by certain criteria (pool_id, power_state or container) for use in other resources.
 
 ## Example Usage
 
@@ -11,6 +11,8 @@ data "xenorchestra_pool" "pool" {
 
 data "xenorchestra_vms" "vms" {
   pool_id = data.xenorchestra_pool.pool.id
+  power_state = "Running"
+  container = data.xenorchestra_pool.pool.master
 }
 
 output "vms" {
@@ -23,6 +25,8 @@ output "vms" {
 ## Argument Reference
 
 * pool_id - (Required) The ID of the pool the vms belong to.
+* container - (Optional) The ID of the pool the vms belong to.
+* power_state - (Optional) The power state of the vms (Running / Halted)
 
 ## Attributes Reference
 

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -28,30 +28,25 @@ output "vms_length" {
 ## Argument Reference
 
 * pool_id - (Required) The ID of the pool the vms belong to.
-* host - (Optional) The Id of the host (container) the vms belong to.
+* host - (Optional) The ID of the host (container) the vms belong to.
 * power_state - (Optional) The power state of the vms ("Running" / "Halted")
 
 ## Attributes Reference
 
-* id - The Id of the pool the storage repository exists on.
-* pool_id - The Id of the pool the storage repository exists on.
+* id - The CRC-32 checksum based on arguments passed to this data source.
+* pool_id - The ID of the pool the VM belongs to.
 * vms - A list of information for all vms found in this pool.
-    * vms.id - The uuid for this vm.
-    * vms.name_label - The name label for this vm.
-    * vms.cpu - The number of cpu assigned to this vm.
-    * vms.cloud_config - The cloud configuration for this vm.
-    * vms.cloud_network_config - The cloud network configuration for this vm.
-    * vms.tags - The tags assigned to this vm.
-    * vms.memory_max - The maximum memory size for this vm.
-    * vms.affinity_host - The affinity host for this vm.
-    * vms.template - The template used to create this vm.
-    * vms.wait_for_ip - The wait for ip options for this vm.
-    * vms.high_availability - The high availability option for this vm.
-    * vms.resource_set - The resource sets for this vm.
-    * vms.ipv4_addresses - The ipv4 addresses for this vm.
-    * vms.ipv6_addresses - The ipv6 addresses for this vm.
-    
-    
-    
-    
-    
+    * vms.id - The uuid of the VM.
+    * vms.name_label - The name label of the VM.
+    * vms.cpu - The number of cpu's of the VM.
+    * vms.cloud_config - The cloud configuration for this VM.
+    * vms.cloud_network_config - The cloud network configuration for this VM.
+    * vms.tags - The tags applied to the VM.
+    * vms.memory_max - The maximum memory size of the VM.
+    * vms.affinity_host - The affinity host of the VM.
+    * vms.template - The template used to create the VM.
+    * vms.wait_for_ip - The wait for ip option of the VM.
+    * vms.high_availability - The high availability option of the VM.
+    * vms.resource_set - The resource set of this VM.
+    * vms.ipv4_addresses - A list of ipv4 addresses of the vm.
+    * vms.ipv6_addresses - A list of ipv6 addresses of the VM.

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -1,0 +1,52 @@
+# xenorchestra_vms
+
+Provides information about VMs
+
+## Example Usage
+
+```hcl
+data "xenorchestra_pool" "pool" {
+  name_label = "Your pool"
+}
+
+data "xenorchestra_vms" "vms" {
+  pool_id = data.xenorchestra_pool.pool.id
+}
+
+output "vms" {
+  value = tomap({
+  for k, vm in data.xenorchestra_vms.vms.vms : k => vm.memory_max
+  })
+}
+```
+
+## Argument Reference
+
+* pool_id - (Required) The ID of the pool the vms belong to.
+
+## Attributes Reference
+
+* id - The Id of the pool the storage repository exists on.
+* pool_id - The Id of the pool the storage repository exists on.
+* num - The number of vms found for this pool
+* vms - A list of information for all vms found in this pool
+    * vms.id - The uuid for this vm
+    * vms.name_label - The name label for this vm
+    * vms.cpu - The number of cpu assigned to this vm
+    * vms.cloud_config - The cloud configuration for this vm
+    * vms.cloud_network_config - The cloud network configuration for this vm
+    * vms.tags - The tags assigned to this vm
+    * vms.memory_max - The maximum memory size for this vm
+    * vms.affinity_host - The affinity host for this vm
+    * vms.template - The template used to create this vm
+    * vms.wait_for_ip - The wait for ip options for this vm
+    * vms.high_availability - The high availability option for this vm
+    * vms.high_availability - The high availability option for this vm
+    * vms.resource_set - The resource sets for this vm
+    * vms.ipv4_addresses - The ipv4 addresses for this vm
+    * vms.ipv6_addresses - The ipv6 addresses for this vm 
+    
+    
+    
+    
+    

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -15,10 +15,13 @@ data "xenorchestra_vms" "vms" {
   container = data.xenorchestra_pool.pool.master
 }
 
-output "vms" {
+output "vms_max_memory_map" {
   value = tomap({
   for k, vm in data.xenorchestra_vms.vms.vms : k => vm.memory_max
   })
+}
+output "vms_length" {
+  value = length(data.xenorchestra_vms.vms.vms)
 }
 ```
 
@@ -32,7 +35,6 @@ output "vms" {
 
 * id - The Id of the pool the storage repository exists on.
 * pool_id - The Id of the pool the storage repository exists on.
-* num - The number of vms found for this pool.
 * vms - A list of information for all vms found in this pool.
     * vms.id - The uuid for this vm.
     * vms.name_label - The name label for this vm.

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -1,6 +1,6 @@
 # xenorchestra_vms
 
-Use this data source to filter Xenorchestra VMs by certain criteria (pool_id, power_state or container) for use in other resources.
+Use this data source to filter Xenorchestra VMs by certain criteria (pool_id, power_state or host) for use in other resources.
 
 ## Example Usage
 
@@ -12,7 +12,7 @@ data "xenorchestra_pool" "pool" {
 data "xenorchestra_vms" "vms" {
   pool_id = data.xenorchestra_pool.pool.id
   power_state = "Running"
-  container = data.xenorchestra_pool.pool.master
+  host = data.xenorchestra_pool.pool.master
 }
 
 output "vms_max_memory_map" {
@@ -28,8 +28,8 @@ output "vms_length" {
 ## Argument Reference
 
 * pool_id - (Required) The ID of the pool the vms belong to.
-* container - (Optional) The ID of the pool the vms belong to.
-* power_state - (Optional) The power state of the vms (Running / Halted)
+* host - (Optional) The Id of the host (container) the vms belong to.
+* power_state - (Optional) The power state of the vms ("Running" / "Halted")
 
 ## Attributes Reference
 

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -1,6 +1,6 @@
 # xenorchestra_vms
 
-Use this data source to filter Xenorchestra VMS by certain criteria (pool_id, power_state or container) for use in other resources.
+Use this data source to filter Xenorchestra VMs by certain criteria (pool_id, power_state or container) for use in other resources.
 
 ## Example Usage
 
@@ -44,7 +44,6 @@ output "vms" {
     * vms.affinity_host - The affinity host for this vm.
     * vms.template - The template used to create this vm.
     * vms.wait_for_ip - The wait for ip options for this vm.
-    * vms.high_availability - The high availability option for this vm.
     * vms.high_availability - The high availability option for this vm.
     * vms.resource_set - The resource sets for this vm.
     * vms.ipv4_addresses - The ipv4 addresses for this vm.

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -29,24 +29,24 @@ output "vms_length" {
 
 * pool_id - (Required) The ID of the pool the vms belong to.
 * host - (Optional) The ID of the host (container) the vms belong to.
-* power_state - (Optional) The power state of the vms ("Running" / "Halted")
+* power_state - (Optional) The power state of the vms. ("Running" / "Halted")
 
 ## Attributes Reference
 
 * id - The CRC-32 checksum based on arguments passed to this data source.
 * pool_id - The ID of the pool the VM belongs to.
 * vms - A list of information for all vms found in this pool.
-    * vms.id - The uuid of the VM.
-    * vms.name_label - The name label of the VM.
-    * vms.cpu - The number of cpu's of the VM.
-    * vms.cloud_config - The cloud configuration for this VM.
-    * vms.cloud_network_config - The cloud network configuration for this VM.
+    * vms.id - The uuid for the VM.
+    * vms.name_label - The name label for the VM.
+    * vms.cpu - The number of cpu's for the VM.
+    * vms.cloud_config - The cloud configuration for the VM.
+    * vms.cloud_network_config - The cloud network configuration for the VM.
     * vms.tags - The tags applied to the VM.
-    * vms.memory_max - The maximum memory size of the VM.
-    * vms.affinity_host - The affinity host of the VM.
+    * vms.memory_max - The maximum memory size for the VM.
+    * vms.affinity_host - The affinity host for the VM.
     * vms.template - The template used to create the VM.
-    * vms.wait_for_ip - The wait for ip option of the VM.
-    * vms.high_availability - The high availability option of the VM.
-    * vms.resource_set - The resource set of this VM.
-    * vms.ipv4_addresses - A list of ipv4 addresses of the vm.
-    * vms.ipv6_addresses - A list of ipv6 addresses of the VM.
+    * vms.wait_for_ip - The wait for ip option for the VM.
+    * vms.high_availability - The high availability option for the VM.
+    * vms.resource_set - The resource set for the VM.
+    * vms.ipv4_addresses - A list of ipv4 addresses for the VM.
+    * vms.ipv6_addresses - A list of ipv6 addresses for the VM.

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -28,23 +28,23 @@ output "vms" {
 
 * id - The Id of the pool the storage repository exists on.
 * pool_id - The Id of the pool the storage repository exists on.
-* num - The number of vms found for this pool
-* vms - A list of information for all vms found in this pool
-    * vms.id - The uuid for this vm
-    * vms.name_label - The name label for this vm
-    * vms.cpu - The number of cpu assigned to this vm
-    * vms.cloud_config - The cloud configuration for this vm
-    * vms.cloud_network_config - The cloud network configuration for this vm
-    * vms.tags - The tags assigned to this vm
-    * vms.memory_max - The maximum memory size for this vm
-    * vms.affinity_host - The affinity host for this vm
-    * vms.template - The template used to create this vm
-    * vms.wait_for_ip - The wait for ip options for this vm
-    * vms.high_availability - The high availability option for this vm
-    * vms.high_availability - The high availability option for this vm
-    * vms.resource_set - The resource sets for this vm
-    * vms.ipv4_addresses - The ipv4 addresses for this vm
-    * vms.ipv6_addresses - The ipv6 addresses for this vm 
+* num - The number of vms found for this pool.
+* vms - A list of information for all vms found in this pool.
+    * vms.id - The uuid for this vm.
+    * vms.name_label - The name label for this vm.
+    * vms.cpu - The number of cpu assigned to this vm.
+    * vms.cloud_config - The cloud configuration for this vm.
+    * vms.cloud_network_config - The cloud network configuration for this vm.
+    * vms.tags - The tags assigned to this vm.
+    * vms.memory_max - The maximum memory size for this vm.
+    * vms.affinity_host - The affinity host for this vm.
+    * vms.template - The template used to create this vm.
+    * vms.wait_for_ip - The wait for ip options for this vm.
+    * vms.high_availability - The high availability option for this vm.
+    * vms.high_availability - The high availability option for this vm.
+    * vms.resource_set - The resource sets for this vm.
+    * vms.ipv4_addresses - The ipv4 addresses for this vm.
+    * vms.ipv6_addresses - The ipv6 addresses for this vm.
     
     
     

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -1,0 +1,84 @@
+package xoa
+
+import (
+	"log"
+	"strings"
+
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceXoaVms() *schema.Resource {
+
+	return &schema.Resource{
+		Read: dataSourceVmsRead,
+		Schema: map[string]*schema.Schema{
+			"vms": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     resourceVm(),
+			},
+			"pool_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceVmsRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(client.XOClient)
+	poolId := d.Get("pool_id").(string)
+
+	vms, err := c.GetVms()
+	log.Printf("[DEBUG] found %d vms in pool\n", len(vms))
+	if err != nil {
+		return err
+	}
+
+	if err = d.Set("vms", vmToMapList(vms, c)); err != nil {
+		return err
+	}
+	d.SetId(poolId)
+	return nil
+
+}
+
+func vmToMapList(vms []client.Vm, c client.XOClient) []map[string]interface{} {
+
+	result := make([]map[string]interface{}, 0, len(vms))
+	for _, vm := range vms {
+		log.Printf("[DEBUG] IPS %s\n", vm.Addresses)
+		var ipv4 []string
+		var ipv6 []string
+		for key, address := range vm.Addresses {
+			if strings.Contains(key, "ipv4") {
+				ipv4 = append(ipv4, address)
+			} else if strings.Contains(key, "ipv6") {
+				ipv6 = append(ipv6, address)
+			}
+		}
+		log.Printf("[DEBUG] VBD on %s (%s) %s\n", vm.VBDs, vm.NameLabel, vm.Id)
+		hostMap := map[string]interface{}{
+			"id":                   vm.Id,
+			"name_label":           vm.NameLabel,
+			"cpus":                 vm.CPUs.Number,
+			"cloud_config":         vm.CloudConfig,
+			"disk":                 vm.Disks,
+			"cloud_network_config": vm.CloudNetworkConfig,
+			"tags":                 vm.Tags,
+			"memory_max":           vm.Memory.Size,
+			"affinity_host":        vm.AffinityHost,
+			"template":             vm.Template,
+			"wait_for_ip":          vm.WaitForIps,
+			"high_availability":    vm.HA,
+			"resource_set":         vm.ResourceSet,
+			"ipv4_addresses":       ipv4,
+			"ipv6_addresses":       ipv6,
+			//			"pool_id":    vm.PoolId,
+		}
+		result = append(result, hostMap)
+	}
+
+	return result
+}

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -22,7 +22,7 @@ func dataSourceXoaVms() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"container": &schema.Schema{
+			"host": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -38,7 +38,7 @@ func dataSourceVmsRead(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 	searchVm := client.Vm{
 		PowerState: d.Get("power_state").(string),
-		Container:  d.Get("container").(string),
+		Host:       d.Get("host").(string),
 		PoolId:     d.Get("pool_id").(string),
 	}
 
@@ -50,8 +50,8 @@ func dataSourceVmsRead(d *schema.ResourceData, m interface{}) error {
 	if err = d.Set("vms", vmToMapList(vms)); err != nil {
 		return err
 	}
-	if searchVm.Container != "" {
-		d.SetId(searchVm.Container)
+	if searchVm.Host != "" {
+		d.SetId(searchVm.Host)
 		return nil
 	}
 	d.SetId(searchVm.PoolId)
@@ -89,7 +89,7 @@ func vmToMapList(vms []client.Vm) []map[string]interface{} {
 			"ipv4_addresses":       ipv4,
 			"ipv6_addresses":       ipv6,
 			"power_state":          vm.PowerState,
-			"container":            vm.Container,
+			"host":                 vm.Host,
 			"auto_poweron":         vm.AutoPoweron,
 			"name_description":     vm.NameDescription,
 		}

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -50,11 +51,7 @@ func dataSourceVmsRead(d *schema.ResourceData, m interface{}) error {
 	if err = d.Set("vms", vmToMapList(vms)); err != nil {
 		return err
 	}
-	if searchVm.Host != "" {
-		d.SetId(searchVm.Host)
-		return nil
-	}
-	d.SetId(searchVm.PoolId)
+	d.SetId(internal.Strings([]string{searchVm.PowerState, searchVm.PoolId, searchVm.Host}))
 	return nil
 
 }

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -97,6 +97,8 @@ func vmToMapList(vms []client.Vm) []map[string]interface{} {
 			"ipv6_addresses":       ipv6,
 			"power_state":          vm.PowerState,
 			"container":            vm.Container,
+			"auto_poweron":         vm.AutoPoweron,
+			"name_description":     vm.NameDescription,
 		}
 		result = append(result, hostMap)
 	}

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -18,10 +18,6 @@ func dataSourceXoaVms() *schema.Resource {
 				Computed: true,
 				Elem:     resourceVm(),
 			},
-			"num": &schema.Schema{
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"pool_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -52,9 +48,6 @@ func dataSourceVmsRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if err = d.Set("vms", vmToMapList(vms)); err != nil {
-		return err
-	}
-	if err = d.Set("num", len(vms)); err != nil {
 		return err
 	}
 	if searchVm.Container != "" {

--- a/xoa/data_source_vms_test.go
+++ b/xoa/data_source_vms_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -20,7 +21,8 @@ func TestAccXenorchestraDataSource_vms(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckXenorchestraDataSourceVms(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttrSet(resourceName, "sum")),
+					resource.TestCheckResourceAttrSet(resourceName, "pool_id"),
+					resource.TestMatchResourceAttr(resourceName, "vms.#", regexp.MustCompile("^[1-9][0-9]*$"))),
 			},
 		},
 	},

--- a/xoa/data_source_vms_test.go
+++ b/xoa/data_source_vms_test.go
@@ -1,0 +1,51 @@
+package xoa
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccXenorchestraDataSource_vms(t *testing.T) {
+	resourceName := "data.xenorchestra_vms.vms"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccXenorchestraDataSourceVmsConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckXenorchestraDataSourceVms(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "sum")),
+			},
+		},
+	},
+	)
+}
+
+func testAccXenorchestraDataSourceVmsConfig() string {
+	return fmt.Sprintf(`
+data "xenorchestra_vms" "vms" {
+    pool_id = "%s"
+}
+`, accTestPool.Id)
+}
+
+func testAccCheckXenorchestraDataSourceVms(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Vms data source: %s", n)
+		}
+
+		log.Printf("[DEBUG] Found resource again %v", s.RootModule().Resources)
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Vms data source ID not set")
+		}
+		return nil
+	}
+}

--- a/xoa/internal/hashcode.go
+++ b/xoa/internal/hashcode.go
@@ -29,12 +29,8 @@ func String(s string) int {
 func Strings(strings []string) string {
 	var buf bytes.Buffer
 
-	for i, s := range strings {
-		var format = "%s"
-		if i != len(strings)-1 {
-			format = fmt.Sprint(format, "-")
-		}
-		buf.WriteString(fmt.Sprintf(format, s))
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))

--- a/xoa/internal/hashcode.go
+++ b/xoa/internal/hashcode.go
@@ -29,8 +29,12 @@ func String(s string) int {
 func Strings(strings []string) string {
 	var buf bytes.Buffer
 
-	for _, s := range strings {
-		buf.WriteString(fmt.Sprintf("%s-", s))
+	for i, s := range strings {
+		var format = "%s"
+		if i != len(strings)-1 {
+			format = fmt.Sprint(format, "-")
+		}
+		buf.WriteString(fmt.Sprintf(format, s))
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))

--- a/xoa/provider.go
+++ b/xoa/provider.go
@@ -51,6 +51,7 @@ func Provider() *schema.Provider {
 			"xenorchestra_resource_set": dataSourceXoaResourceSet(),
 			"xenorchestra_sr":           dataSourceXoaStorageRepository(),
 			"xenorchestra_user":         dataSourceXoaUser(),
+			"xenorchestra_vms":          dataSourceXoaVms(),
 			"xenorchestra_vdi":          dataSourceXoaVDI(),
 		},
 		ConfigureFunc: xoaConfigure,

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -129,7 +129,7 @@ func resourceVmSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"container": &schema.Schema{
+		"host": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -129,6 +129,10 @@ func resourceVmSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"container": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"wait_for_ip": &schema.Schema{
 			Type:     schema.TypeBool,
 			Default:  false,

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -259,6 +259,25 @@ func resourceVmSchema() map[string]*schema.Schema {
 	}
 }
 
+func resourceRecord() *schema.Resource {
+	duration := 5 * time.Minute
+	return &schema.Resource{
+		Create: resourceVmCreate,
+		Read:   resourceVmRead,
+		Update: resourceVmUpdate,
+		Delete: resourceVmDelete,
+		Importer: &schema.ResourceImporter{
+			State: RecordImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: &duration,
+			Update: &duration,
+			Delete: &duration,
+		},
+		Schema: resourceVmSchema(),
+	}
+}
+
 func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
@@ -1085,23 +1104,4 @@ func suppressAttachedDiffWhenHalted(k, old, new string, d *schema.ResourceData) 
 	}
 	log.Printf("[DEBUG] VM '%s' attribute has transitioned from '%s' to '%s' when PowerState '%s'. Suppress diff: %t", k, old, new, powerState, suppress)
 	return
-}
-
-func resourceRecord() *schema.Resource {
-	duration := 5 * time.Minute
-	return &schema.Resource{
-		Create: resourceVmCreate,
-		Read:   resourceVmRead,
-		Update: resourceVmUpdate,
-		Delete: resourceVmDelete,
-		Importer: &schema.ResourceImporter{
-			State: RecordImport,
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: &duration,
-			Update: &duration,
-			Delete: &duration,
-		},
-		Schema: resourceVmSchema(),
-	}
 }

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -26,233 +26,232 @@ var validInstallationMethods = []string{
 	"network",
 }
 
-func resourceRecord() *schema.Resource {
-	duration := 5 * time.Minute
+func resourceVm() *schema.Resource {
+	vmSchema := resourceVmSchema()
+	delete(vmSchema, "cdrom")
+	delete(vmSchema, "installation_method")
+	vmSchema["id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+
 	return &schema.Resource{
-		Create: resourceVmCreate,
-		Read:   resourceVmRead,
-		Update: resourceVmUpdate,
-		Delete: resourceVmDelete,
-		Importer: &schema.ResourceImporter{
-			State: RecordImport,
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: &duration,
-			Update: &duration,
-			Delete: &duration,
-		},
-		Schema: map[string]*schema.Schema{
-			"affinity_host": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"name_label": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"name_description": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"cloud_network_config": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"auto_poweron": &schema.Schema{
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			"power_state": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"installation_method": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validation.StringInSlice(validInstallationMethods, false),
-				ConflictsWith: []string{"cdrom"},
-			},
-			"high_availability": &schema.Schema{
-				Type:         schema.TypeString,
-				Default:      "",
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(validHaOptions, false),
-			},
-			"template": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"cloud_config": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"core_os": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"cpu_cap": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-			},
-			"cpu_weight": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-			},
-			"cpus": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"memory_max": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"resource_set": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"ipv4_addresses": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"ipv6_addresses": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"wait_for_ip": &schema.Schema{
-				Type:     schema.TypeBool,
-				Default:  false,
-				Optional: true,
-			},
-			"cdrom": &schema.Schema{
-				Type:          schema.TypeList,
-				Optional:      true,
-				ConflictsWith: []string{"installation_method"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-				// This should be increased but I don't understand
-				// the use cases for multiple ISOs just yet. For now
-				// limit it to a single ISO
-				MaxItems: 1,
-			},
-			"network": &schema.Schema{
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attached": &schema.Schema{
-							Type:             schema.TypeBool,
-							Default:          true,
-							Optional:         true,
-							DiffSuppressFunc: suppressAttachedDiffWhenHalted,
-						},
-						"device": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"network_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"mac_address": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							StateFunc: func(val interface{}) string {
-								unformattedMac := val.(string)
-								mac, err := net.ParseMAC(unformattedMac)
-								if err != nil {
-									panic(fmt.Sprintf("Mac address `%s` was not parsable. This should never happened because Terraform's validation should happen before this is stored into state", unformattedMac))
-								}
-								return mac.String()
+		Schema: vmSchema,
+	}
+}
 
-							},
-							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-								mac_address := val.(string)
-								if _, err := net.ParseMAC(mac_address); err != nil {
-									errs = append(errs, fmt.Errorf("%s Mac Address is invalid", mac_address))
-								}
-								return
-
-							},
-						},
-						"ipv4_addresses": &schema.Schema{
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"ipv6_addresses": &schema.Schema{
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"disk": &schema.Schema{
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"sr_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name_label": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name_description": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"size": &schema.Schema{
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-						"attached": &schema.Schema{
-							Type:             schema.TypeBool,
-							Default:          true,
-							Optional:         true,
-							DiffSuppressFunc: suppressAttachedDiffWhenHalted,
-						},
-						"position": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vdi_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vbd_id": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-			"tags": resourceTags(),
+func resourceVmSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"affinity_host": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
 		},
+		"name_label": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"name_description": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"cloud_network_config": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"auto_poweron": &schema.Schema{
+			Type:     schema.TypeBool,
+			Default:  false,
+			Optional: true,
+		},
+		"power_state": &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"installation_method": &schema.Schema{
+			Type:          schema.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.StringInSlice(validInstallationMethods, false),
+			ConflictsWith: []string{"cdrom"},
+		},
+		"high_availability": &schema.Schema{
+			Type:         schema.TypeString,
+			Default:      "",
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(validHaOptions, false),
+		},
+		"template": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"cloud_config": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"core_os": &schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"cpu_cap": &schema.Schema{
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  0,
+		},
+		"cpu_weight": &schema.Schema{
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  0,
+		},
+		"cpus": &schema.Schema{
+			Type:     schema.TypeInt,
+			Required: true,
+		},
+		"memory_max": &schema.Schema{
+			Type:     schema.TypeInt,
+			Required: true,
+		},
+		"resource_set": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"ipv4_addresses": &schema.Schema{
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"ipv6_addresses": &schema.Schema{
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"wait_for_ip": &schema.Schema{
+			Type:     schema.TypeBool,
+			Default:  false,
+			Optional: true,
+		},
+		"cdrom": &schema.Schema{
+			Type:          schema.TypeList,
+			Optional:      true,
+			ConflictsWith: []string{"installation_method"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			// This should be increased but I don't understand
+			// the use cases for multiple ISOs just yet. For now
+			// limit it to a single ISO
+			MaxItems: 1,
+		},
+		"network": &schema.Schema{
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"attached": &schema.Schema{
+						Type:             schema.TypeBool,
+						Default:          true,
+						Optional:         true,
+						DiffSuppressFunc: suppressAttachedDiffWhenHalted,
+					},
+					"device": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"network_id": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"mac_address": &schema.Schema{
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+						StateFunc: func(val interface{}) string {
+							unformattedMac := val.(string)
+							mac, err := net.ParseMAC(unformattedMac)
+							if err != nil {
+								panic(fmt.Sprintf("Mac address `%s` was not parsable. This should never happened because Terraform's validation should happen before this is stored into state", unformattedMac))
+							}
+							return mac.String()
+
+						},
+						ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+							mac_address := val.(string)
+							if _, err := net.ParseMAC(mac_address); err != nil {
+								errs = append(errs, fmt.Errorf("%s Mac Address is invalid", mac_address))
+							}
+							return
+
+						},
+					},
+					"ipv4_addresses": &schema.Schema{
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"ipv6_addresses": &schema.Schema{
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"disk": &schema.Schema{
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"sr_id": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"name_label": &schema.Schema{
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"name_description": &schema.Schema{
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"size": &schema.Schema{
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+					"attached": &schema.Schema{
+						Type:             schema.TypeBool,
+						Default:          true,
+						Optional:         true,
+						DiffSuppressFunc: suppressAttachedDiffWhenHalted,
+					},
+					"position": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"vdi_id": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"vbd_id": &schema.Schema{
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"tags": resourceTags(),
 	}
 }
 
@@ -1082,4 +1081,23 @@ func suppressAttachedDiffWhenHalted(k, old, new string, d *schema.ResourceData) 
 	}
 	log.Printf("[DEBUG] VM '%s' attribute has transitioned from '%s' to '%s' when PowerState '%s'. Suppress diff: %t", k, old, new, powerState, suppress)
 	return
+}
+
+func resourceRecord() *schema.Resource {
+	duration := 5 * time.Minute
+	return &schema.Resource{
+		Create: resourceVmCreate,
+		Read:   resourceVmRead,
+		Update: resourceVmUpdate,
+		Delete: resourceVmDelete,
+		Importer: &schema.ResourceImporter{
+			State: RecordImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: &duration,
+			Update: &duration,
+			Delete: &duration,
+		},
+		Schema: resourceVmSchema(),
+	}
 }


### PR DESCRIPTION
Continuation of  #161. Rebased by @ddelnano. 

I've tested these changes in the past week in my development environment. Seems to be working as expected. I was not able to identify any bugs or side effects (yet). 



## Todo 

- [ ] Close #161, once this is merged 
- [x] Apply diff patch to reset crc32 hashcode generation in `xoa/internal/hashcode.go`

``` 
Index: xoa/data_source_vms.go
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/xoa/data_source_vms.go b/xoa/data_source_vms.go
--- a/xoa/data_source_vms.go	(revision 470c245132d51d70fee07e45aa0ba9a6a2c37b73)
+++ b/xoa/data_source_vms.go	(revision 8a31b0c725d48cbe88cf930fd0c695285e7ac72d)
@@ -1,11 +1,13 @@
 package xoa
 
 import (
+	"fmt"
+	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
-	"github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -51,7 +53,10 @@
 	if err = d.Set("vms", vmToMapList(vms)); err != nil {
 		return err
 	}
-	d.SetId(internal.Strings([]string{searchVm.PowerState, searchVm.PoolId, searchVm.Host}))
+	hash := internal.String(fmt.Sprintf(
+		"%s-%s-%s-", searchVm.PowerState, searchVm.PoolId, searchVm.Host,
+	))
+	d.SetId(strconv.Itoa(hash))
 	return nil
 
 }
Index: xoa/internal/hashcode.go
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/xoa/internal/hashcode.go b/xoa/internal/hashcode.go
--- a/xoa/internal/hashcode.go	(revision 470c245132d51d70fee07e45aa0ba9a6a2c37b73)
+++ b/xoa/internal/hashcode.go	(revision 267cd3075b2c6a42607e1fce01202b15162b04d4)
@@ -29,12 +29,8 @@
 func Strings(strings []string) string {
 	var buf bytes.Buffer
 
-	for i, s := range strings {
-		var format = "%s"
-		if i != len(strings)-1 {
-			format = fmt.Sprint(format, "-")
-		}
-		buf.WriteString(fmt.Sprintf(format, s))
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))
```

Please note, that this patch is using `"%s-%s-%s-"` for the formatting directive, to match the output of `internal.Strings()` function.  

# Example 

Example shows how to  retrieve CPU and memory information for running VM's. In combination with #160 users will be able to get information about free CPU's and memory, grouped by host. I am using this feature to take an automated decision, on which host the next VM resource should be created. 


## Terraform configuration 
```hcl 
data "xenorchestra_pool" "pool" {
  name_label = "MY-POOL"
}

data "xenorchestra_hosts" "hosts" {
  pool_id = data.xenorchestra_pool.pool.id
}

data "xenorchestra_vms" "vms" {
  pool_id = data.xenorchestra_pool.pool.id
  power_state = "Running"
}

output "host-info" {
  value = local.hostInfo
}

locals {
  hostInfo = tomap({
  for k, host in data.xenorchestra_hosts.hosts.hosts : host.name_label => {
    max_memory : host.memory,
    max_cpu : host.cpus.cores,
    usage_memory: sum(tolist([for k, vm in data.xenorchestra_vms.vms.vms : vm.memory_max if vm.host == host.id])),
    usage_cpu: sum(tolist([for k, vm in data.xenorchestra_vms.vms.vms : vm.cpus if vm.host == host.id]))
  }})
  
}

```

## Output

```hcl
host-info = tomap({
  "xcp-ng01" = {
    "max_cpu" = 64
    "max_memory" = 274485751808
    "usage_cpu" = 46
    "usage_memory" = 223338295296
  }
  "xcp-ng02" = {
    "max_cpu" = 64
    "max_memory" = 274485751808
    "usage_cpu" = 54
    "usage_memory" = 156766302208
  }
  "xcp-ng03" = {
    "max_cpu" = 64
    "max_memory" = 274485751808
    "usage_cpu" = 56
    "usage_memory" = 151397584896
  }
  "xcp-ng05" = {
    "max_cpu" = 64
    "max_memory" = 274485911552
    "usage_cpu" = 36
    "usage_memory" = 99857977344
  }
  "xcp-ng06" = {
    "max_cpu" = 64
    "max_memory" = 274485911552
    "usage_cpu" = 48
    "usage_memory" = 241591898112
  }
  "xcp-ng07" = {
    "max_cpu" = 48
    "max_memory" = 274484908032
    "usage_cpu" = 48
    "usage_memory" = 201326579712
  }
})

