### PR TITLE
Update vms data source memory_max

### DIFF
--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -77,7 +77,7 @@ func vmToMapList(vms []client.Vm) []map[string]interface{} {
 			"cloud_config":         vm.CloudConfig,
 			"cloud_network_config": vm.CloudNetworkConfig,
 			"tags":                 vm.Tags,
-			"memory_max":           vm.Memory.Size,
+			"memory_max":           vm.Memory.Static[1],
 			"affinity_host":        vm.AffinityHost,
 			"template":             vm.Template,
 			"wait_for_ip":          vm.WaitForIps,


### PR DESCRIPTION
After doing some more testing, I noticed that the new vms data source's `memory_max` attribute was probably set wrong. 

`vm.Memory.Static[1]` is also used to create and update the vms. 

Unfortunately, I did not notice that `vm.Memory.Size` and  `vm.Memory.Static[1]` have slightly different values. Sorry for that. 
