### PR TITLE
Support more missing parameters in vm set

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -80,6 +80,7 @@ type Vm struct {
 	Tags               []string          `json:"tags"`
 	Videoram           Videoram          `json:"videoram,omitempty"`
 	Vga                string            `json:"vga,omitempty"`
+	StartDelay         int               `json:startDelay,omitempty"`
 
 	// These fields are used for passing in disk inputs when
 	// creating Vms, however, this is not a real field as far
@@ -195,6 +196,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		params["vga"] = vga
 	}
 
+	startDelay := vmReq.StartDelay
+	if startDelay != 0 {
+		params["startDelay"] = startDelay
+	}
+
 	// if len(vmReq.BlockedOperations) > 0 {
 	// 	blockedOperations := map[string]string{}
 	// 	for _, v := range vmReq.BlockedOperations {
@@ -287,8 +293,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		// pv_args
 
 		// virtualizationMode hvm or pv, cannot be set after vm is created (requires conversion)
-
-		// can be set at runtime vga valid values (std, cirrus), videoram (= [1, 2, 4, 8, 16]) - https://github.com/vatesfr/xen-orchestra/blob/9139c5e9d6b4306ba4078e6fa128a36f65417792/packages/xo-server/src/xapi/mixins/vm.mjs#L18
 
 		// hasVendorDevice must be applied when the vm is halted and only applies to windows machines - https://github.com/xapi-project/xen-api/blob/889b83c47d46c4df65fe58b01caed284dab8dc93/ocaml/idl/datamodel_vm.ml#L1168
 

--- a/client/vm.go
+++ b/client/vm.go
@@ -78,13 +78,14 @@ type Vm struct {
 	HA                 string            `json:"high_availability"`
 	CloudConfig        string            `json:"cloudConfig"`
 	ResourceSet        string            `json:"resourceSet,omitempty"`
-	SecureBoot         bool              `json:"secureBoot,omitempty"`
-	NicType            string            `json:"nicType,omitempty"`
-	Tags               []string          `json:"tags"`
-	Videoram           Videoram          `json:"videoram,omitempty"`
-	Vga                string            `json:"vga,omitempty"`
-	StartDelay         int               `json:startDelay,omitempty"`
-	Host               string            `json:"$container"`
+	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+	// SecureBoot         bool              `json:"secureBoot,omitempty"`
+	NicType    string   `json:"nicType,omitempty"`
+	Tags       []string `json:"tags"`
+	Videoram   Videoram `json:"videoram,omitempty"`
+	Vga        string   `json:"vga,omitempty"`
+	StartDelay int      `json:startDelay,omitempty"`
+	Host       string   `json:"$container"`
 
 	// These fields are used for passing in disk inputs when
 	// creating Vms, however, this is not a real field as far
@@ -190,11 +191,12 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"memoryMax":        vmReq.Memory.Static[1],
 		"existingDisks":    existingDisks,
 		"nicType":          vmReq.NicType,
-		"secureBoot":       vmReq.SecureBoot,
-		"expNestedHvm":     vmReq.ExpNestedHvm,
-		"VDIs":             vdis,
-		"VIFs":             vmReq.VIFsMap,
-		"tags":             vmReq.Tags,
+		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+		// "secureBoot":       vmReq.SecureBoot,
+		"expNestedHvm": vmReq.ExpNestedHvm,
+		"VDIs":         vdis,
+		"VIFs":         vmReq.VIFsMap,
+		"tags":         vmReq.Tags,
 	}
 
 	videoram := vmReq.Videoram.Value
@@ -307,10 +309,11 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
 	}
 
-	secureBoot := vmReq.SecureBoot
-	if secureBoot {
-		params["secureBoot"] = true
-	}
+	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+	// secureBoot := vmReq.SecureBoot
+	// if secureBoot {
+	// 	params["secureBoot"] = true
+	// }
 
 	blockedOperations := map[string]interface{}{}
 	for k, v := range vmReq.BlockedOperations {

--- a/client/vm.go
+++ b/client/vm.go
@@ -266,15 +266,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	)
 }
 
-func (v Vm) BlockedOperationsList() []string {
-	blockedOperations := []string{}
-	for k, _ := range v.BlockedOperations {
-		blockedOperations = append(blockedOperations, k)
-	}
-
-	return blockedOperations
-}
-
 func createVdiMap(disk Disk) map[string]interface{} {
 	return map[string]interface{}{
 		"$SR":              disk.SrId,
@@ -313,7 +304,7 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 
 		// hasVendorDevice must be applied when the vm is halted and only applies to windows machines - https://github.com/xapi-project/xen-api/blob/889b83c47d46c4df65fe58b01caed284dab8dc93/ocaml/idl/datamodel_vm.ml#L1168
 
-		// share seems to be a resource set thing. This can be accomplished with the resource set resource so we can ignore it.
+		// share relates to resource sets. This can be accomplished with the resource set resource so supporting it isn't necessary
 
 		// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(

--- a/client/vm.go
+++ b/client/vm.go
@@ -29,6 +29,9 @@ type Boot struct {
 	Firmware string `json:"firmware,omitempty"`
 }
 
+// The XO api sometimes returns the videoram field as an int
+// and sometimes as a string. This overrides the default json
+// unmarshalling so that we can handle both of these cases
 type Videoram struct {
 	Value int `json:"-"`
 }

--- a/client/vm.go
+++ b/client/vm.go
@@ -23,9 +23,15 @@ type MemoryObject struct {
 	Size    int   `json:"size"`
 }
 
+type Boot struct {
+	Firmware string            `json:"firmware,omitempty"`
+	Order    map[string]string `json:"order,omitempty"`
+}
+
 type Vm struct {
 	Addresses          map[string]string `json:"addresses,omitempty"`
 	BlockedOperations  map[string]string `json:"blockedOperations,omitempty"`
+	Boot               Boot              `json:"boot,omitempty"`
 	Type               string            `json:"type,omitempty"`
 	Id                 string            `json:"id,omitempty"`
 	AffinityHost       string            `json:"affinityHost,omitempty"`
@@ -161,6 +167,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"tags":              vmReq.Tags,
 	}
 
+	firmware := vmReq.Boot.Firmware
+	if firmware != "" {
+		params["hvmBootFirmware"] = firmware
+	}
+
 	// if len(vmReq.BlockedOperations) > 0 {
 	// 	blockedOperations := map[string]string{}
 	// 	for _, v := range vmReq.BlockedOperations {
@@ -249,7 +260,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		// TODO: These need more investigation before they are implemented
 		// pv_args
 
-		// blockedOperations {"value": true|false}, set at runtime will fail if setting doesn't exist and must be explictly set to false to remove
 		// hvmBootFirware (default, bios, uefi) can be set at runtime
 
 		//  secureBoot (true, false) can be set at runtime

--- a/client/vm.go
+++ b/client/vm.go
@@ -181,6 +181,7 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"bootAfterCreate":  true,
 		"name_label":       vmReq.NameLabel,
 		"name_description": vmReq.NameDescription,
+		"hvmBootFirmware":  vmReq.Boot.Firmware,
 		"template":         vmReq.Template,
 		"coreOs":           false,
 		"cpuCap":           nil,
@@ -194,11 +195,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"VDIs":             vdis,
 		"VIFs":             vmReq.VIFsMap,
 		"tags":             vmReq.Tags,
-	}
-
-	firmware := vmReq.Boot.Firmware
-	if firmware != "" {
-		params["hvmBootFirmware"] = firmware
 	}
 
 	videoram := vmReq.Videoram.Value
@@ -287,6 +283,7 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		"affinityHost":      vmReq.AffinityHost,
 		"name_label":        vmReq.NameLabel,
 		"name_description":  vmReq.NameDescription,
+		"hvmBootFirmware":   vmReq.Boot.Firmware,
 		"auto_poweron":      vmReq.AutoPoweron,
 		"resourceSet":       resourceSet,
 		"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
@@ -326,10 +323,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 	}
 	params["blockedOperations"] = blockedOperations
 
-	firmware := vmReq.Boot.Firmware
-	if vmReq.Boot.Firmware != "" {
-		params["hvmBootFirmware"] = firmware
-	}
 	log.Printf("[DEBUG] VM params for vm.set: %#v", params)
 
 	var success bool

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -72,6 +72,11 @@ var vmObjectData string = `
   "$poolId": "cadf25ab-91ff-6fc0-041f-5a7033c4bc78"
 }`
 
+var vmObjectWithNumericVideoram string = `
+{
+  "videoram": 8
+}`
+
 var data string = `
 {
   "6944cce9-5ce0-a853-ee9c-bcc8281b597f": {
@@ -132,7 +137,7 @@ var data string = `
 }
 `
 
-func TestThatUnmarshalingWorks(t *testing.T) {
+func TestUnmarshal(t *testing.T) {
 	var allObjectRes allObjectResponse
 	err := json.Unmarshal([]byte(data), &allObjectRes.Objects)
 
@@ -152,6 +157,17 @@ func TestUnmarshalingVmObject(t *testing.T) {
 
 	if !validateVmObject(vmObj) {
 		t.Fatalf("VmObject has not passed validation")
+	}
+
+	var vmObjVideoramNumeric Vm
+	err = json.Unmarshal([]byte(vmObjectWithNumericVideoram), &vmObjVideoramNumeric)
+
+	if err != nil {
+		t.Fatalf("error: %v. Need to have VM object: %v", err, vmObjVideoramNumeric)
+	}
+
+	if vmObjVideoramNumeric.Videoram.Value != 8 {
+		t.Fatalf("Expected vm to Unmarshal from numerical videoram value")
 	}
 
 }
@@ -204,6 +220,10 @@ func validateVmObject(o Vm) bool {
 	}
 
 	if o.ResourceSet == "" {
+		return false
+	}
+
+	if o.Videoram.Value != 8 {
 		return false
 	}
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -88,6 +88,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 
 
 * `high_availabililty` - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.
+* `hvm_boot_firmware` - (Optional) The firmware to use for the VM. Possible values are `bios` and `uefi`. Defaults to empty string.
 * `installation_method` - (Optional) This cannot be used with `cdrom`. Possible values are `network` which allows a VM to boot via PXE.
 * `auto_poweron` - (Optional) If the VM will automatically turn on. Defaults to `false`.
 * `affinity_host` - (Optional) The preferred host you would like the VM to run on. If changed on an existing VM it will require a reboot for the VM to be rescheduled.

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -89,6 +89,7 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 
 * `high_availabililty` - (Optional) The restart priority for the VM. Possible values are `best-effort`, `restart` and empty string (no restarts on failure. Defaults to empty string.
 * `hvm_boot_firmware` - (Optional) The firmware to use for the VM. Possible values are `bios` and `uefi`. Defaults to empty string.
+* `exp_nested_hvm` - (Optional) Boolean parameter that allows a VM to use nested virtualization.
 * `installation_method` - (Optional) This cannot be used with `cdrom`. Possible values are `network` which allows a VM to boot via PXE.
 * `auto_poweron` - (Optional) If the VM will automatically turn on. Defaults to `false`.
 * `affinity_host` - (Optional) The preferred host you would like the VM to run on. If changed on an existing VM it will require a reboot for the VM to be rescheduled.

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -58,6 +58,7 @@ resource "xenorchestra_vm" "bar" {
 ```
 
 ## Argument Reference
+* `blocked_operations` - (Optional) List of operations on a VM that are not permitted. Examples include: clean_reboot, clean_shutdown, hard_reboot, hard_shutdown, pause, shutdown, suspend, destroy. This can be used to prevent a VM from being destroyed. The entire list can be found here
 * `name_label` - (Required) The name of VM.
 * `name_description` - (Optional) The description of the VM.
 * `template` - (Required) The ID of the VM template to create the new VM from.
@@ -102,6 +103,10 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
     * `name_description` - (Optional) A description for the disk.
     * `size` - (Required) The size in bytes of the disk.
 * `tags` - (Optional) List of labels (strings) that are used to identify and organize resources. These are equivalent to Xenserver [tags](https://docs.citrix.com/en-us/xencenter/7-1/resources-tagging.html).
+* `vga` - (Optional) The video adapter the VM should use. Possible values include std and cirrus.
+* `videoram` - (Optional) The videoram option the VM should use. Possible values include 1, 2, 4, 8, 16
+* `nic_type` - (Optional) The NIC type the VM should use. Possible options are '' (Realtek RTL8139) and e1000.
+* `start_delay` - (Optional) Number of seconds the VM should be delayed from starting
 
 ## Attributes Reference
 In addition to all the arguments above, the following attributes are exported:

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -29,6 +29,7 @@ var validHaOptions = []string{
 }
 
 var validFirmware = []string{
+	"",
 	"bios",
 	"uefi",
 }
@@ -89,7 +90,7 @@ func resourceVmSchema() map[string]*schema.Schema {
 		},
 		"hvm_boot_firmware": &schema.Schema{
 			Type:         schema.TypeString,
-			Default:      "bios",
+			Default:      "",
 			Optional:     true,
 			ValidateFunc: validation.StringInSlice(validFirmware, false),
 		},
@@ -765,6 +766,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		AutoPoweron:       autoPowerOn,
 		AffinityHost:      affinityHost,
 		BlockedOperations: blockOperations,
+		ExpNestedHvm:      d.Get("exp_nested_hvm").(bool),
 		StartDelay:        d.Get("start_delay").(int),
 		Vga:               d.Get("vga").(string),
 		SecureBoot:        d.Get("secure_boot").(bool),

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -954,7 +954,7 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	if err := d.Set("tags", resource.Tags); err != nil {
 		return err
 	}
-	if err := d.Set("blocked_operations", resource.BlockedOperationsList()); err != nil {
+	if err := d.Set("blocked_operations", vmBlockedOperationsToList(resource)); err != nil {
 		return err
 	}
 
@@ -1000,6 +1000,15 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	}
 
 	return nil
+}
+
+func vmBlockedOperationsToList(v client.Vm) []string {
+	blockedOperations := []string{}
+	for k, _ := range v.BlockedOperations {
+		blockedOperations = append(blockedOperations, k)
+	}
+
+	return blockedOperations
 }
 
 func diskHash(value interface{}) int {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -176,11 +176,12 @@ func resourceVmSchema() map[string]*schema.Schema {
 			Default:  0,
 			Optional: true,
 		},
-		"secure_boot": &schema.Schema{
-			Type:     schema.TypeBool,
-			Default:  false,
-			Optional: true,
-		},
+		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+		// "secure_boot": &schema.Schema{
+		// 	Type:     schema.TypeBool,
+		// 	Default:  false,
+		// 	Optional: true,
+		// },
 		"nic_type": &schema.Schema{
 			Type:     schema.TypeString,
 			Default:  "",
@@ -422,11 +423,12 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		Tags:         vmTags,
 		Disks:        ds,
 		Installation: installation,
-		SecureBoot:   d.Get("secure_boot").(bool),
-		NicType:      d.Get("nic_type").(string),
-		VIFsMap:      network_maps,
-		StartDelay:   d.Get("start_delay").(int),
-		WaitForIps:   d.Get("wait_for_ip").(bool),
+		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+		// SecureBoot:   d.Get("secure_boot").(bool),
+		NicType:    d.Get("nic_type").(string),
+		VIFsMap:    network_maps,
+		StartDelay: d.Get("start_delay").(int),
+		WaitForIps: d.Get("wait_for_ip").(bool),
 		Videoram: client.Videoram{
 			Value: d.Get("videoram").(int),
 		},
@@ -769,7 +771,8 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		ExpNestedHvm:      d.Get("exp_nested_hvm").(bool),
 		StartDelay:        d.Get("start_delay").(int),
 		Vga:               d.Get("vga").(string),
-		SecureBoot:        d.Get("secure_boot").(bool),
+		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+		// SecureBoot:        d.Get("secure_boot").(bool),
 		Boot: client.Boot{
 			Firmware: d.Get("hvm_boot_firmware").(string),
 		},
@@ -929,9 +932,10 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	d.Set("resource_set", resource.ResourceSet)
 	d.Set("power_state", resource.PowerState)
 
-	if err := d.Set("secure_boot", resource.SecureBoot); err != nil {
-		return err
-	}
+	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
+	// if err := d.Set("secure_boot", resource.SecureBoot); err != nil {
+	// 	return err
+	// }
 
 	if err := d.Set("hvm_boot_firmware", resource.Boot.Firmware); err != nil {
 		return err

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -174,6 +174,11 @@ func resourceRecord() *schema.Resource {
 				Default:  0,
 				Optional: true,
 			},
+			"start_delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Default:  0,
+				Optional: true,
+			},
 			"secure_boot": &schema.Schema{
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -396,6 +401,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		SecureBoot:   d.Get("secure_boot").(bool),
 		NicType:      d.Get("nic_type").(string),
 		VIFsMap:      network_maps,
+		StartDelay:   d.Get("start_delay").(int),
 		WaitForIps:   d.Get("wait_for_ip").(bool),
 		Videoram: client.Videoram{
 			Value: d.Get("videoram").(int),
@@ -902,6 +908,10 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	}
 
 	if err := d.Set("videoram", resource.Videoram); err != nil {
+		return err
+	}
+
+	if err := d.Set("start_delay", resource.StartDelay); err != nil {
 		return err
 	}
 

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -22,6 +22,11 @@ var validHaOptions = []string{
 	"restart",
 }
 
+var validFirmware = []string{
+	"bios",
+	"uefi",
+}
+
 var validInstallationMethods = []string{
 	"network",
 }
@@ -69,6 +74,12 @@ func resourceRecord() *schema.Resource {
 				Type:     schema.TypeBool,
 				Default:  false,
 				Optional: true,
+			},
+			"hvm_boot_firmware": &schema.Schema{
+				Type:         schema.TypeString,
+				Default:      "",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(validFirmware, false),
 			},
 			"power_state": &schema.Schema{
 				Type:     schema.TypeString,
@@ -329,11 +340,14 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	vm, err := c.CreateVm(client.Vm{
 		AffinityHost:      d.Get("affinity_host").(string),
 		BlockedOperations: blockedOperations,
-		NameLabel:         d.Get("name_label").(string),
-		NameDescription:   d.Get("name_description").(string),
-		Template:          d.Get("template").(string),
-		CloudConfig:       d.Get("cloud_config").(string),
-		ResourceSet:       d.Get("resource_set").(string),
+		Boot: client.Boot{
+			Firmware: d.Get("hvm_boot_firmware").(string),
+		},
+		NameLabel:       d.Get("name_label").(string),
+		NameDescription: d.Get("name_description").(string),
+		Template:        d.Get("template").(string),
+		CloudConfig:     d.Get("cloud_config").(string),
+		ResourceSet:     d.Get("resource_set").(string),
 		CPUs: client.CPUs{
 			Number: d.Get("cpus").(int),
 		},

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -397,8 +397,10 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		NicType:      d.Get("nic_type").(string),
 		VIFsMap:      network_maps,
 		WaitForIps:   d.Get("wait_for_ip").(bool),
-		Videoram:     strconv.Itoa(d.Get("videoram").(int)),
-		Vga:          d.Get("vga").(string),
+		Videoram: client.Videoram{
+			Value: d.Get("videoram").(int),
+		},
+		Vga: d.Get("vga").(string),
 	},
 		d.Timeout(schema.TimeoutCreate),
 	)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1150,17 +1150,43 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckXenorchestraVmDestroy,
 		Steps: []resource.TestStep{
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 	  blocked_operations = ["copy"]
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "1"),
+			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.0", "copy"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "0"),
+			// 	),
+			// },
+			// This fails to boot but will work once a VM was created
 			{
 				Config: testAccVmConfigUpdateAttr(
 					nameLabel,
 					`
-				  blocked_operations = ["copy"]
+					vga = "cirrus"
+					videoram = 16
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "blocked_operations.0", "copy"),
+					resource.TestCheckResourceAttr(resourceName, "vga", "std"),
+					resource.TestCheckResourceAttr(resourceName, "videoram", "16"),
 				),
 			},
 			{
@@ -1171,32 +1197,102 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vga", "cirrus"),
+					resource.TestCheckResourceAttr(resourceName, "videoram", "8"),
 				),
 			},
-			{
-				Config: testAccVmConfigUpdateAttr(
-					nameLabel,
-					`
-					hvm_boot_firmware = "uefi"
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccVmExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
-				),
-			},
-			{
-				Config: testAccVmConfigUpdateAttr(
-					nameLabel,
-					"",
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccVmExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckNoResourceAttr(resourceName, "hvm_boot_firmware"),
-				),
-			},
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 		exp_nested_hvm = true
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "exp_nested_hvm", "true"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "exp_nested_hvm", "false"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 		nic_type = "e1000"
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "nic_type", "e1000"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "nic_type", ""),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 		secure_boot = true
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "secure_boot", "true"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "secure_boot", "false"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 		hvm_boot_firmware = "uefi"
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", ""),
+			// 	),
+			// },
 		},
 	})
 }

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1588,7 +1588,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10737418240
+      size = 10001317888
     }
 
     tags = [
@@ -2225,7 +2225,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10737418240
+      size = 10001317888
     }
 
     %s

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1185,7 +1185,7 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
 				),
 			},
-			// TODO: () Uncomment once the issues with secure_boot are figured out
+			// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 			// {
 			// 	Config: testAccVmConfigUpdateAttr(
 			// 		nameLabel,

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1150,37 +1150,89 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckXenorchestraVmDestroy,
 		Steps: []resource.TestStep{
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// 	  blocked_operations = ["copy"]
-			// 	`),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "1"),
-			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.0", "copy"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "0"),
-			// 	),
-			// },
-			// This fails to boot but will work once a VM was created
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					"",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
 			{
 				Config: testAccVmConfigUpdateAttr(
 					nameLabel,
 					`
-					start_delay = 1
-				`),
+                                    hvm_boot_firmware = "uefi"
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
+				),
+			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+                                    hvm_boot_firmware = "uefi"
+                                    secure_boot = true
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
+					resource.TestCheckResourceAttr(resourceName, "secure_boot", "true"),
+				),
+			},
+
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+                              blocked_operations = ["copy"]
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "blocked_operations.0", "copy"),
+				),
+			},
+
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+                                    vga = "cirrus"
+                                    videoram = 16
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "vga", "cirrus"),
+					resource.TestCheckResourceAttr(resourceName, "videoram", "16"),
+				),
+			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+                                    nic_type = "e1000"
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "nic_type", "e1000"),
+				),
+			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+				    start_delay = 1
+			`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -1191,118 +1243,10 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 			// 	Config: testAccVmConfigUpdateAttr(
 			// 		nameLabel,
 			// 		`
-			// 		vga = "cirrus"
-			// 		videoram = 16
-			// 	`),
+			// `),
 			// 	Check: resource.ComposeAggregateTestCheckFunc(
 			// 		testAccVmExists(resourceName),
 			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "vga", "std"),
-			// 		resource.TestCheckResourceAttr(resourceName, "videoram", "16"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "vga", "cirrus"),
-			// 		resource.TestCheckResourceAttr(resourceName, "videoram", "8"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// 		exp_nested_hvm = true
-			// 	`),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "exp_nested_hvm", "true"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "exp_nested_hvm", "false"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// 		nic_type = "e1000"
-			// 	`),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "nic_type", "e1000"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "nic_type", ""),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// 		secure_boot = true
-			// 	`),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "secure_boot", "true"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "secure_boot", "false"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// 		hvm_boot_firmware = "uefi"
-			// 	`),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
-			// 	),
-			// },
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		"",
-			// 	),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 		resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", ""),
 			// 	),
 			// },
 		},
@@ -1640,7 +1584,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10001317888
+      size = 10737418240
     }
 
     tags = [
@@ -2277,7 +2221,7 @@ resource "xenorchestra_vm" "bar" {
     disk {
       sr_id = "%s"
       name_label = "disk 1"
-      size = 10001317888
+      size = 10737418240
     }
 
     %s

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1174,6 +1174,29 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "blocked_operations.#", "0"),
 				),
 			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
+					hvm_boot_firmware = "uefi"
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
+				),
+			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					"",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckNoResourceAttr(resourceName, "hvm_boot_firmware"),
+				),
+			},
 		},
 	})
 }

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1173,20 +1173,21 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
 				),
 			},
-			{
-				Config: testAccVmConfigUpdateAttr(
-					nameLabel,
-					`
-                                    hvm_boot_firmware = "uefi"
-                                    secure_boot = true
-                            `),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccVmExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
-					resource.TestCheckResourceAttr(resourceName, "secure_boot", "true"),
-				),
-			},
+			// TODO: () Uncomment once the issues with secure_boot are figured out
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// hvm_boot_firmware = "uefi"
+			// secure_boot = true
+			// `),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "hvm_boot_firmware", "uefi"),
+			// 		resource.TestCheckResourceAttr(resourceName, "secure_boot", "true"),
+			// 	),
+			// },
 
 			{
 				Config: testAccVmConfigUpdateAttr(
@@ -1240,16 +1241,6 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "start_delay", "1"),
 				),
 			},
-			// {
-			// 	Config: testAccVmConfigUpdateAttr(
-			// 		nameLabel,
-			// 		`
-			// `),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		testAccVmExists(resourceName),
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 	),
-			// },
 		},
 	})
 }

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1179,28 +1179,40 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 				Config: testAccVmConfigUpdateAttr(
 					nameLabel,
 					`
-					vga = "cirrus"
-					videoram = 16
+					start_delay = 1
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "vga", "std"),
-					resource.TestCheckResourceAttr(resourceName, "videoram", "16"),
+					resource.TestCheckResourceAttr(resourceName, "start_delay", "1"),
 				),
 			},
-			{
-				Config: testAccVmConfigUpdateAttr(
-					nameLabel,
-					"",
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccVmExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "vga", "cirrus"),
-					resource.TestCheckResourceAttr(resourceName, "videoram", "8"),
-				),
-			},
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		`
+			// 		vga = "cirrus"
+			// 		videoram = 16
+			// 	`),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "vga", "std"),
+			// 		resource.TestCheckResourceAttr(resourceName, "videoram", "16"),
+			// 	),
+			// },
+			// {
+			// 	Config: testAccVmConfigUpdateAttr(
+			// 		nameLabel,
+			// 		"",
+			// 	),
+			// 	Check: resource.ComposeAggregateTestCheckFunc(
+			// 		testAccVmExists(resourceName),
+			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
+			// 		resource.TestCheckResourceAttr(resourceName, "vga", "cirrus"),
+			// 		resource.TestCheckResourceAttr(resourceName, "videoram", "8"),
+			// 	),
+			// },
 			// {
 			// 	Config: testAccVmConfigUpdateAttr(
 			// 		nameLabel,

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1165,6 +1165,18 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 				Config: testAccVmConfigUpdateAttr(
 					nameLabel,
 					`
+                                    exp_nested_hvm = true
+                            `),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "exp_nested_hvm", "true"),
+				),
+			},
+			{
+				Config: testAccVmConfigUpdateAttr(
+					nameLabel,
+					`
                                     hvm_boot_firmware = "uefi"
                             `),
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
This PR partially addresses #145

## Todo
- [ ] ~Fix issues with the `secure_boot` argument~ -- I'm going to defer this until later since this PR has been so long lived
- [ ] ~Add support for cpusMask, cpuWeight, cpuCap and coresPerSocket~ -- I'm going to defer this until later since this PR has been so long lived
- [x] Document the remaining missing attributes (expNestedHvm and hvmBootFirmware needs to be documented)
- [x] Update documentation with new arguments
- [x] Revert changes to disk size
- [x] Remove all `secure_boot` changes