### PR TITLE
filtered params before appending them to the vm.set call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,7 @@ type XOClient interface {
 	CreateVm(vmReq Vm, d time.Duration) (*Vm, error)
 	GetVm(vmReq Vm) (*Vm, error)
 	GetVms(vm Vm) ([]Vm, error)
-	UpdateVm(vmReq Vm) (*Vm, error)
+	UpdateVm(vmReq Vm, params map[string]interface{}) (*Vm, error)
 	DeleteVm(id string) error
 	HaltVm(vmReq Vm) error
 	StartVm(id string) error

--- a/client/vm.go
+++ b/client/vm.go
@@ -275,39 +275,39 @@ func createVdiMap(disk Disk) map[string]interface{} {
 	}
 }
 
-func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
-	var resourceSet interface{} = vmReq.ResourceSet
-	if vmReq.ResourceSet == "" {
-		resourceSet = nil
-	}
-	params := map[string]interface{}{
-		"id":                vmReq.Id,
-		"affinityHost":      vmReq.AffinityHost,
-		"name_label":        vmReq.NameLabel,
-		"name_description":  vmReq.NameDescription,
-		"hvmBootFirmware":   vmReq.Boot.Firmware,
-		"auto_poweron":      vmReq.AutoPoweron,
-		"resourceSet":       resourceSet,
-		"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
-		"CPUs":              vmReq.CPUs.Number,
-		"memoryMax":         vmReq.Memory.Static[1],
-		"nicType":           vmReq.NicType,
-		"expNestedHvm":      vmReq.ExpNestedHvm,
-		"startDelay":        vmReq.StartDelay,
-		"vga":               vmReq.Vga,
-		"videoram":          vmReq.Videoram.Value,
-		// TODO: These need more investigation before they are implemented
-		// pv_args
+func (c *Client) UpdateVm(vmReq Vm, params map[string]interface{}) (*Vm, error) {
+	// var resourceSet interface{} = vmReq.ResourceSet
+	// if vmReq.ResourceSet == "" {
+	// 	resourceSet = nil
+	// }
+	// params := map[string]interface{}{
+	// 	"id":                vmReq.Id,
+	// 	"affinityHost":      vmReq.AffinityHost,
+	// 	"name_label":        vmReq.NameLabel,
+	// 	"name_description":  vmReq.NameDescription,
+	// 	"hvmBootFirmware":   vmReq.Boot.Firmware,
+	// 	"auto_poweron":      vmReq.AutoPoweron,
+	// 	"resourceSet":       resourceSet,
+	// 	"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
+	// 	"CPUs":              vmReq.CPUs.Number,
+	// 	"memoryMax":         vmReq.Memory.Static[1],
+	// 	"nicType":           vmReq.NicType,
+	// 	"expNestedHvm":      vmReq.ExpNestedHvm,
+	// 	"startDelay":        vmReq.StartDelay,
+	// 	"vga":               vmReq.Vga,
+	// 	"videoram":          vmReq.Videoram.Value,
+	// TODO: These need more investigation before they are implemented
+	// pv_args
 
-		// virtualizationMode hvm or pv, cannot be set after vm is created (requires conversion)
+	// virtualizationMode hvm or pv, cannot be set after vm is created (requires conversion)
 
-		// hasVendorDevice must be applied when the vm is halted and only applies to windows machines - https://github.com/xapi-project/xen-api/blob/889b83c47d46c4df65fe58b01caed284dab8dc93/ocaml/idl/datamodel_vm.ml#L1168
+	// hasVendorDevice must be applied when the vm is halted and only applies to windows machines - https://github.com/xapi-project/xen-api/blob/889b83c47d46c4df65fe58b01caed284dab8dc93/ocaml/idl/datamodel_vm.ml#L1168
 
-		// share relates to resource sets. This can be accomplished with the resource set resource so supporting it isn't necessary
+	// share relates to resource sets. This can be accomplished with the resource set resource so supporting it isn't necessary
 
-		// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
-		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
-	}
+	// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
+	// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
+	// }
 
 	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 	// secureBoot := vmReq.SecureBoot

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -180,7 +180,11 @@ func TestUpdateVmWithUpdatesThatRequireHalt(t *testing.T) {
 
 	prevCPUs := accVm.CPUs.Number
 	updatedCPUs := prevCPUs + 1
-	vm, err := c.UpdateVm(Vm{Id: accVm.Id, CPUs: CPUs{Number: updatedCPUs}, NameLabel: "terraform testing", Memory: MemoryObject{Static: []int{0, 4294967296}}})
+	params := map[string]interface{}{
+		"id":   accVm.Id,
+		"CPUs": updatedCPUs,
+	}
+	vm, err := c.UpdateVm(Vm{Id: accVm.Id, CPUs: CPUs{Number: updatedCPUs}, NameLabel: "terraform testing", Memory: MemoryObject{Static: []int{0, 4294967296}}}, params)
 
 	if err != nil {
 		t.Fatalf("failed to update vm with error: %v", err)

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -588,14 +588,14 @@ func resourceVmRead(d *schema.ResourceData, m interface{}) error {
 type VmField int
 
 const (
-	NAME_LABEL VmField = iota
-	AFFINITY_HOST
+	AFFINITY_HOST VmField = iota
+	NAME_LABEL 
 	NAME_DESCRIPTION
 	HVM_BOOT_FIRMWARE
-	CPUS
 	AUTO_POWER_ON
-	HIGH_AVAILABILITY
 	RESOURCE_SET
+	HIGH_AVAILABILITY
+	CPUS
 	MEMORY_MAX
 	EXP_NESTED_HVM
 	START_DELAY
@@ -615,14 +615,14 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 
 	mappings := map[VmField]VmFieldMapping{
-		NAME_LABEL:        {"name_label", "name_label"},
 		AFFINITY_HOST:     {"affinity_host", "affinityHost"},
+		NAME_LABEL:        {"name_label", "name_label"},
 		NAME_DESCRIPTION:  {"name_description", "name_description"},
 		HVM_BOOT_FIRMWARE: {"hvm_boot_firmware", "hvmBootFirmware"},
-		CPUS:              {"cpus", "CPUs"},
 		AUTO_POWER_ON:     {"auto_poweron", "auto_poweron"},
-		HIGH_AVAILABILITY: {"high_availability", "high_availability"},
 		RESOURCE_SET:      {"resource_set", "resourceSet"},
+		HIGH_AVAILABILITY: {"high_availability", "high_availability"},
+		CPUS:              {"cpus", "CPUs"},
 		MEMORY_MAX:        {"memory_max", "memoryMax"},
 		EXP_NESTED_HVM:    {"exp_nested_hvm", "expNestedHvm"},
 		START_DELAY:       {"start_delay", "startDelay"},


### PR DESCRIPTION
Hello there, 
I created this PR containing a proposal, how passing the params to the vm.set call could also be realised. I already reported the issue in #171.

TBH, I think my current implementation still needs a bit of work, as this is my first time writing any go-lang code. If there are any problems or required style changes to my code, simply let me know & I will try to make the adjustments. 

I would be happy to receive a review & which parts require further work.