### PR TITLE
Fix resource set permission issue #171

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -60,6 +60,7 @@ func (c *Client) GetAllUsers() ([]User, error) {
 		"dummy": "dummy",
 	}
 	users := []User{}
+	log.Printf("[DEBUG] Calling user.getAll\n")
 	err := c.Call("user.getAll", params, &users)
 
 	log.Printf("[DEBUG] Found the following users: %v\n", users)

--- a/client/vm.go
+++ b/client/vm.go
@@ -274,10 +274,6 @@ func createVdiMap(disk Disk) map[string]interface{} {
 }
 
 func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
-	var resourceSet interface{} = vmReq.ResourceSet
-	if vmReq.ResourceSet == "" {
-		resourceSet = nil
-	}
 	params := map[string]interface{}{
 		"id":                vmReq.Id,
 		"affinityHost":      vmReq.AffinityHost,
@@ -285,7 +281,6 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		"name_description":  vmReq.NameDescription,
 		"hvmBootFirmware":   vmReq.Boot.Firmware,
 		"auto_poweron":      vmReq.AutoPoweron,
-		"resourceSet":       resourceSet,
 		"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
 		"CPUs":              vmReq.CPUs.Number,
 		"memoryMax":         vmReq.Memory.Static[1],
@@ -304,6 +299,10 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 
 		// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
+	}
+
+	if vmReq.ResourceSet != "" {
+		params["resourceSet"] = vmReq.ResourceSet
 	}
 
 	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out

--- a/client/vm.go
+++ b/client/vm.go
@@ -64,6 +64,15 @@ type FlatResourceSet struct {
 	Id string
 }
 
+// This ensures when a FlatResourceSet is printed in debug logs
+// that the string value of the Id is used rather than the pointer
+// value. Since the purpose of this struct is to flatten resource
+// sets to a string, it makes the logs properly reflect what is
+// being logged.
+func (rs *FlatResourceSet) String() string {
+	return rs.Id
+}
+
 func (rs *FlatResourceSet) UnmarshalJSON(data []byte) (err error) {
 	return json.Unmarshal(data, &rs.Id)
 }

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -173,6 +173,16 @@ func TestUnmarshalingVmObject(t *testing.T) {
 
 }
 
+func TestFlatResourceSetStringerInterface(t *testing.T) {
+	rs := &FlatResourceSet{
+		Id: "id",
+	}
+	v := fmt.Sprintf("%s", rs)
+	if v != rs.Id {
+		t.Errorf("expected FlatResourceSet to print Id '%s' value rather than value '%s'", rs.Id, v)
+	}
+}
+
 func TestFlatResourceSetMarshalling(t *testing.T) {
 	rs := &FlatResourceSet{
 		Id: "id",

--- a/xoa/data_source_vms.go
+++ b/xoa/data_source_vms.go
@@ -82,13 +82,15 @@ func vmToMapList(vms []client.Vm) []map[string]interface{} {
 			"template":             vm.Template,
 			"wait_for_ip":          vm.WaitForIps,
 			"high_availability":    vm.HA,
-			"resource_set":         vm.ResourceSet,
 			"ipv4_addresses":       ipv4,
 			"ipv6_addresses":       ipv6,
 			"power_state":          vm.PowerState,
 			"host":                 vm.Host,
 			"auto_poweron":         vm.AutoPoweron,
 			"name_description":     vm.NameDescription,
+		}
+		if vm.ResourceSet != nil {
+			hostMap["resource_set"] = vm.ResourceSet.Id
 		}
 		result = append(result, hostMap)
 	}

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -393,6 +393,12 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		blockedOperations[b.(string)] = "true"
 	}
 
+	var rs *client.FlatResourceSet
+	if rsId, ok := d.GetOk("resource_set"); ok {
+		rs = &client.FlatResourceSet{
+			Id: rsId.(string),
+		}
+	}
 	vm, err := c.CreateVm(client.Vm{
 		AffinityHost:      d.Get("affinity_host").(string),
 		BlockedOperations: blockedOperations,
@@ -404,9 +410,7 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		NameDescription: d.Get("name_description").(string),
 		Template:        d.Get("template").(string),
 		CloudConfig:     d.Get("cloud_config").(string),
-		ResourceSet: &client.FlatResourceSet{
-			Id: d.Get("resource_set").(string),
-		},
+		ResourceSet:     rs,
 		CPUs: client.CPUs{
 			Number: d.Get("cpus").(int),
 		},

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -595,7 +595,10 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 	cpus := d.Get("cpus").(int)
 	autoPowerOn := d.Get("auto_poweron").(bool)
 	ha := d.Get("high_availability").(string)
-	rs := d.Get("resource_set").(string)
+	rs := ""
+	if d.HasChange("resource_set") {
+		rs = d.Get("resource_set").(string)
+	}
 	memoryMax := d.Get("memory_max").(int)
 
 	vm, err := c.GetVm(client.Vm{Id: id})

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -404,7 +404,9 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		NameDescription: d.Get("name_description").(string),
 		Template:        d.Get("template").(string),
 		CloudConfig:     d.Get("cloud_config").(string),
-		ResourceSet:     d.Get("resource_set").(string),
+		ResourceSet: &client.FlatResourceSet{
+			Id: d.Get("resource_set").(string),
+		},
 		CPUs: client.CPUs{
 			Number: d.Get("cpus").(int),
 		},
@@ -595,9 +597,11 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 	cpus := d.Get("cpus").(int)
 	autoPowerOn := d.Get("auto_poweron").(bool)
 	ha := d.Get("high_availability").(string)
-	rs := ""
+	var rs *client.FlatResourceSet
 	if d.HasChange("resource_set") {
-		rs = d.Get("resource_set").(string)
+		rs = &client.FlatResourceSet{
+			Id: d.Get("resource_set").(string),
+		}
 	}
 	memoryMax := d.Get("memory_max").(int)
 
@@ -925,7 +929,11 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 	d.Set("name_description", resource.NameDescription)
 	d.Set("high_availability", resource.HA)
 	d.Set("auto_poweron", resource.AutoPoweron)
-	d.Set("resource_set", resource.ResourceSet)
+	if resource.ResourceSet != nil {
+		d.Set("resource_set", resource.ResourceSet.Id)
+	} else {
+		d.Set("resource_set", "")
+	}
 	d.Set("power_state", resource.PowerState)
 
 	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -411,15 +411,19 @@ func TestAccXenorchestraVm_ensureVmsInResourceSetsCanBeUpdatedByNonAdminUsers(t 
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckXenorchestraVmDestroy,
 		Steps: []resource.TestStep{
+			// Create a resource set and cloud config template with an admin user
 			{
 				Config: testAccVmResourceSet(vmName) + testAccCloudConfigConfig(fmt.Sprintf("vm-template-%s", vmName), "template"),
 			},
+			// Create a VM using the resource set from the previous step
 			{
 				Config: testAccVmConfigWithResourceSetUserAndPassword(vmName, accUser.Email, accUserPassword),
 			},
+			// Verify that the non admin user can update the VM. This is the main assertion of the test
 			{
 				Config: testAccVmConfigWithResourceSetUserAndDescription(vmName, "new description", accUser.Email, accUserPassword),
 			},
+			// Re-run with the admin user so that it can delete the resource set and cloud config
 			{
 				Config: testAccVmConfigWithResourceSetUserAndPassword(vmName, adminUser, adminPassword),
 			},


### PR DESCRIPTION
This is a follow up to #172 

## Todo
- [x] Create non admin user for the test rather than relying on an existing user.
- [x] Remove hardcoding of the precreated user uuid. This is because non admin users cannot call `user.getAll`
- [x] Fix vm acceptance test that verifies resource sets can be created and updated
- [x] Ensure that the xen orchestra client properly logs the new `resourceSet` field in requests (using a pointer makes you believe that it is sending a pointer address to the XO api, but in reality it isn't)
- [x] `make testacc` passes