### PR TITLE
Update the documentation to include additional attributes

### DIFF
--- a/docs/data-sources/cloud_config.md
+++ b/docs/data-sources/cloud_config.md
@@ -20,3 +20,4 @@ using the data source.
 
 ## Attributes Reference
 * id - Id of the resource set.
+* template - The contents of the cloud-config.


### PR DESCRIPTION
Update the documentation to include additional attributes that are also on the resource set. This attribute was missing from the docs and is needed to create VMs using cloud-config.