### PR TITLE
Add test sweepers for the existing resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,13 @@ plan: build
 apply:
 	terraform apply
 
+sweep:
+	TF_ACC=1 $(TF_LOG) go test -sweep=true
+
 test: testclient testacc
 
 testclient:
 	cd client; go test $(TEST) -v -count 1
 
-testacc:
+testacc: sweep
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ apply:
 	terraform apply
 
 sweep:
-	TF_ACC=1 $(TF_LOG) go test -sweep=true
+	TF_ACC=1 $(TF_LOG) go test $(TEST) -sweep=true -v
 
 test: testclient testacc
 

--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ const (
 
 type XOClient interface {
 	GetObjectsWithTags(tags []string) ([]Object, error)
+	GetAllObjectsOfType(obj XoObject, response interface{}) error
 
 	CreateVm(vmReq Vm, d time.Duration) (*Vm, error)
 	GetVm(vmReq Vm) (*Vm, error)

--- a/client/vm.go
+++ b/client/vm.go
@@ -574,18 +574,18 @@ func RemoveVmsWithNamePrefix(prefix string) func(string) error {
 			return fmt.Errorf("error getting client: %s", err)
 		}
 
-		vms, err := c.GetVms(Vm{})
+		var vmsMap map[string]Vm
+		err = c.GetAllObjectsOfType(Vm{}, &vmsMap)
 		if err != nil {
 			return fmt.Errorf("error getting vms: %s", err)
 		}
-		for _, vm := range vms {
+		for _, vm := range vmsMap {
 			if strings.HasPrefix(vm.NameLabel, prefix) {
-				fmt.Println(fmt.Sprintf("[DEBUG] Would have deleted VM `%s`", vm.NameLabel))
-				// TODO: uncomment once this is tested
-				// err := c.DeleteVm(vm.Id)
-				// if err != nil {
-				// 	log.Printf("error destroying vm `%s` during sweep: %s", vm.NameLabel, err)
-				// }
+				fmt.Printf("[DEBUG] Deleting vm `%s`\n", vm.NameLabel)
+				err := c.DeleteVm(vm.Id)
+				if err != nil {
+					log.Printf("error destroying vm `%s` during sweep: %s", vm.NameLabel, err)
+				}
 			}
 		}
 		return nil

--- a/client/vm.go
+++ b/client/vm.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -563,4 +564,30 @@ func FindOrCreateVmForTests(vm *Vm, poolId, srId, templateName, tag string) {
 	}
 
 	*vm = *vmRes
+}
+
+func RemoveVmsWithNamePrefix(prefix string) func(string) error {
+	return func(_ string) error {
+		fmt.Println("[DEBUG] Running vm sweeper")
+		c, err := NewClient(GetConfigFromEnv())
+		if err != nil {
+			return fmt.Errorf("error getting client: %s", err)
+		}
+
+		vms, err := c.GetVms(Vm{})
+		if err != nil {
+			return fmt.Errorf("error getting vms: %s", err)
+		}
+		for _, vm := range vms {
+			if strings.HasPrefix(vm.NameLabel, prefix) {
+				fmt.Println(fmt.Sprintf("[DEBUG] Would have deleted VM `%s`", vm.NameLabel))
+				// TODO: uncomment once this is tested
+				// err := c.DeleteVm(vm.Id)
+				// if err != nil {
+				// 	log.Printf("error destroying vm `%s` during sweep: %s", vm.NameLabel, err)
+				// }
+			}
+		}
+		return nil
+	}
 }

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -20,6 +20,8 @@ var disklessTestTemplate client.Template
 var testIsoName string
 
 func TestMain(m *testing.M) {
+	// TODO: Call terraform-plugin-sdk's TestMain if we detect that the sweeper
+	// flag was provided
 	_, runSetup := os.LookupEnv("TF_ACC")
 
 	if runSetup {

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -1,11 +1,13 @@
 package xoa
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 var testObjectIndex int = 1
@@ -20,30 +22,38 @@ var disklessTestTemplate client.Template
 var testIsoName string
 
 func TestMain(m *testing.M) {
-	// TODO: Call terraform-plugin-sdk's TestMain if we detect that the sweeper
-	// flag was provided
-	_, runSetup := os.LookupEnv("TF_ACC")
+	// This leverages the existing flag defined in the terraform-plugin-sdk
+	// repo defined below
+	// https://github.com/hashicorp/terraform-plugin-sdk/blob/2c03a32a9d1be63a12eb18aaf12d2c5270c42346/helper/resource/testing.go#L58
+	flag.Parse()
+	flagSweep := flag.Lookup("sweep")
 
-	if runSetup {
-		client.FindPoolForTests(&accTestPool)
-		client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
-		client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
-		client.FindHostForTests(accTestPool.Master, &accTestHost)
-		client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
-		client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
-		client.CreateUser(&accUser)
-		testIsoName = os.Getenv("XOA_ISO")
+	if flagSweep != nil && flagSweep.Value.String() != "" {
+		resource.TestMain(m)
+	} else {
+		_, runSetup := os.LookupEnv("TF_ACC")
+
+		if runSetup {
+			client.FindPoolForTests(&accTestPool)
+			client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
+			client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
+			client.FindHostForTests(accTestPool.Master, &accTestHost)
+			client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
+			client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
+			client.CreateUser(&accUser)
+			testIsoName = os.Getenv("XOA_ISO")
+		}
+
+		code := m.Run()
+
+		if runSetup {
+			client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
+			client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
+			client.RemoveTagFromAllObjects(accTestPrefix)("")
+			client.RemoveUsersWithPrefix(accTestPrefix)("")
+			client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
+		}
+
+		os.Exit(code)
 	}
-
-	code := m.Run()
-
-	if runSetup {
-		client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
-		client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
-		client.RemoveTagFromAllObjects(accTestPrefix)("")
-		client.RemoveUsersWithPrefix(accTestPrefix)("")
-		client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
-	}
-
-	os.Exit(code)
 }

--- a/xoa/resource_user_test.go
+++ b/xoa/resource_user_test.go
@@ -1,0 +1,16 @@
+package xoa
+
+import (
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Until a user resource exists this just ensures that the user test sweeper
+// is run
+
+func init() {
+	resource.AddTestSweepers("user", &resource.Sweeper{
+		Name: "user",
+		F:    client.RemoveUsersWithPrefix(accTestPrefix),
+	})
+}

--- a/xoa/resource_user_test.go
+++ b/xoa/resource_user_test.go
@@ -9,8 +9,8 @@ import (
 // is run
 
 func init() {
-	resource.AddTestSweepers("user", &resource.Sweeper{
-		Name: "user",
+	resource.AddTestSweepers("xenorchestra_user", &resource.Sweeper{
+		Name: "xenorchestra_user",
 		F:    client.RemoveUsersWithPrefix(accTestPrefix),
 	})
 }

--- a/xoa/resource_xenorchestra_cloud_config_test.go
+++ b/xoa/resource_xenorchestra_cloud_config_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("xenorchestra_cloud_config", &resource.Sweeper{
+		Name: "xenorchestra_cloud_config",
+		F:    client.RemoveCloudConfigsWithPrefix(accTestPrefix),
+	})
+}
+
 func TestAccXenorchestraCloudConfig_readAfterDelete(t *testing.T) {
 	templateName := "testing"
 	templateText := "template body"

--- a/xoa/resource_xenorchestra_resource_set_test.go
+++ b/xoa/resource_xenorchestra_resource_set_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var rsName string = "terraform-acc-resource-set-resource"
+var rsName string = fmt.Sprintf("%s-resource-set-resource", accTestPrefix)
 
 func init() {
-	resource.AddTestSweepers("resource_set", &resource.Sweeper{
-		Name: "resource_set",
-		F:    client.RemoveResourceSetsWithNamePrefix("terraform-acc"),
+	resource.AddTestSweepers("xenorchestra_resource_set", &resource.Sweeper{
+		Name: "xenorchestra_resource_set",
+		F:    client.RemoveResourceSetsWithNamePrefix(accTestPrefix),
 	})
 }
 

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -324,7 +324,7 @@ func Test_shouldUpdateVif(t *testing.T) {
 }
 
 func TestAccXenorchestraVm_createWithShorterResourceTimeout(t *testing.T) {
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -340,7 +340,7 @@ func TestAccXenorchestraVm_createWithShorterResourceTimeout(t *testing.T) {
 
 func TestAccXenorchestraVm_createAndPlanWithNonExistantVm(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	removeVm := func() {
 		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
@@ -385,7 +385,7 @@ func TestAccXenorchestraVm_createAndPlanWithNonExistantVm(t *testing.T) {
 
 func TestAccXenorchestraVm_createWhenWaitingForIp(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	regex := regexp.MustCompile(`[1-9]*`)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -409,7 +409,7 @@ func TestAccXenorchestraVm_createWhenWaitingForIp(t *testing.T) {
 }
 
 func TestAccXenorchestraVm_cdromAndInstallationMethodsCannotBeSpecifiedTogether(t *testing.T) {
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -426,7 +426,7 @@ func TestAccXenorchestraVm_cdromAndInstallationMethodsCannotBeSpecifiedTogether(
 func TestAccXenorchestraVm_createVmThatInstallsFromTheNetwork(t *testing.T) {
 	t.Skip("For now this test is not implemented. See #156 for more details")
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -450,7 +450,7 @@ func TestAccXenorchestraVm_createAndUpdateDiskNameLabelAndNameDescription(t *tes
 	description := "disk description"
 	updatedNameLabel := "updated disk name label"
 	updatedDescription := "updated description"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -479,7 +479,7 @@ func TestAccXenorchestraVm_createAndUpdateDiskNameLabelAndNameDescription(t *tes
 
 func TestAccXenorchestraVm_createWithTags(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	tag1 := "tag1"
 	tag2 := "tag2"
 	resource.ParallelTest(t, resource.TestCase{
@@ -523,7 +523,7 @@ func TestAccXenorchestraVm_createWithTags(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithDisklessTemplateAndISO(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -544,7 +544,7 @@ func TestAccXenorchestraVm_createWithDisklessTemplateAndISO(t *testing.T) {
 
 func TestAccXenorchestraVm_insertAndEjectCd(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -580,7 +580,7 @@ func TestAccXenorchestraVm_insertAndEjectCd(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithAffinityHost(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	affinityHost := accTestPool.Master
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -600,7 +600,7 @@ func TestAccXenorchestraVm_createWithAffinityHost(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithoutCloudConfig(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -619,7 +619,7 @@ func TestAccXenorchestraVm_createWithoutCloudConfig(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithCloudInitNetworkConfig(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -639,7 +639,7 @@ func TestAccXenorchestraVm_createWithCloudInitNetworkConfig(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithDashedMacAddress(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	macWithDashes := "00-0a-83-b1-c0-01"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -664,7 +664,7 @@ func TestAccXenorchestraVm_createWithDashedMacAddress(t *testing.T) {
 
 func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	macAddress := "00:0a:83:b1:c0:83"
 	otherMacAddress := "00:0a:83:b1:c0:00"
 	macWithDashes := "00-0a-83-b1-c0-01"
@@ -713,7 +713,7 @@ func TestAccXenorchestraVm_createAndUpdateWithMacAddress(t *testing.T) {
 
 func TestAccXenorchestraVm_disconnectAttachedVif(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -745,7 +745,7 @@ func TestAccXenorchestraVm_disconnectAttachedVif(t *testing.T) {
 
 func TestAccXenorchestraVm_attachDisconnectedVif(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	removeVif := func() {
 		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
@@ -799,7 +799,7 @@ func TestAccXenorchestraVm_attachDisconnectedVif(t *testing.T) {
 
 func TestAccXenorchestraVm_attachDisconnectedDisk(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	disconnectDisk := func() {
 		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {
@@ -874,7 +874,7 @@ func TestAccXenorchestraVm_attachDisconnectedDisk(t *testing.T) {
 
 func TestAccXenorchestraVm_disconnectAttachedDisk(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -907,7 +907,7 @@ func TestAccXenorchestraVm_disconnectAttachedDisk(t *testing.T) {
 
 func TestAccXenorchestraVm_createWithMutipleDisks(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -928,7 +928,7 @@ func TestAccXenorchestraVm_createWithMutipleDisks(t *testing.T) {
 
 func TestAccXenorchestraVm_addAndRemoveDisksToVm(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -970,7 +970,7 @@ func TestAccXenorchestraVm_addAndRemoveDisksToVm(t *testing.T) {
 
 func TestAccXenorchestraVm_import(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	checkFn := func(s []*terraform.InstanceState) error {
 		attrs := []string{"id", "name_label"}
 		for _, attr := range attrs {
@@ -1035,7 +1035,7 @@ func testAccCheckXenorchestraVmDestroy(s *terraform.State) error {
 
 func TestAccXenorchestraVm_addVifAndRemoveVif(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1080,7 +1080,7 @@ func TestAccXenorchestraVm_replaceExistingVifs(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	firstMacAddress := "02:00:00:00:00:00"
 	secondMacAddress := "02:00:00:00:00:11"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1255,7 +1255,7 @@ func TestAccXenorchestraVm_updatesWithoutRebootForOtherAttrs(t *testing.T) {
 
 func TestAccXenorchestraVm_updatesThatRequireReboot(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1285,7 +1285,7 @@ func TestAccXenorchestraVm_updatesThatRequireReboot(t *testing.T) {
 
 func TestAccXenorchestraVm_updatingCpusInsideMaxCpuAndMemInsideStaticMaxDoesNotRequireReboot(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		// Use a provider that has a XO client that will error if StartVm
@@ -1318,7 +1318,7 @@ func TestAccXenorchestraVm_updatingCpusInsideMaxCpuAndMemInsideStaticMaxDoesNotR
 
 func TestAccXenorchestraVm_createAndUpdateWithResourceSet(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1346,7 +1346,7 @@ func TestAccXenorchestraVm_createAndUpdateWithResourceSet(t *testing.T) {
 
 func TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
-	vmName := fmt.Sprintf("Terraform testing - %s", t.Name())
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
 	shutdownVm := func() {
 		c, err := client.NewClient(client.GetConfigFromEnv())
 		if err != nil {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func init() {
+	resource.AddTestSweepers("xenorchestra_vm", &resource.Sweeper{
+		Name:         "xenorchestra_vm",
+		F:            client.RemoveVmsWithNamePrefix(accTestPrefix),
+		Dependencies: []string{"xenorchestra_resource_set", "xenorchestra_cloud_config"},
+	})
+}
+
 func Test_extractIpsFromNetworks(t *testing.T) {
 	ipv4 := "169.254.169.254"
 	secondIpv4 := "169.254.255.254"
@@ -2257,7 +2265,8 @@ data "xenorchestra_network" "network" {
 }
 
 resource "xenorchestra_resource_set" "rs" {
-    name = "terraform-vm-acceptance-test"
+    # TODO: Change this to use accTestPrefix during #179
+    name = "terraform-acc"
     subjects = []
     objects = [
 	"${data.xenorchestra_template.template.id}",


### PR DESCRIPTION
This addresses #84 and will aid in merging #179 

## Testing
- [x] Run a test that leaves a VM running (`TestAccXenorchestraVm_createWithShorterResourceTimeout`) twice and verify that the VM is terminated before the test runs
```
# Test passes the first time

$ TEST=TestAccXenorchestraVm_createWithShorterResourceTimeout make testacc
=== RUN   TestAccXenorchestraVm_createWithShorterResourceTimeout
=== PAUSE TestAccXenorchestraVm_createWithShorterResourceTimeout
=== CONT  TestAccXenorchestraVm_createWithShorterResourceTimeout
--- PASS: TestAccXenorchestraVm_createWithShorterResourceTimeout (22.65s)
PASS
[DEBUG] Running sweeper
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa 40.988s
testing: warning: no tests to run
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal        0.040s [no tests to run]


# Test passes the second time and Vm is deleted before the second test runs 
$ TEST=TestAccXenorchestraVm_createWithShorterResourceTimeout make testacc

[ ... ]

[DEBUG] Deleting vm `terraform-acc - TestAccXenorchestraVm_createWithShorterResourceTimeout`


```