### PR TITLE
Update vm.delete to handle the new and old RPC return values in a backwards compatible way

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -416,7 +416,7 @@ func (c *Client) DeleteVm(id string) error {
 	params := map[string]interface{}{
 		"id": id,
 	}
-	// Xen Orchestra versions >= 5.x.x changed this return value to a bool
+	// Xen Orchestra versions >= 5.69.0 changed this return value to a bool
 	// when older versions returned an object. This needs to be an interface
 	// type in order to be backwards compatible while fixing this bug. See
 	// GitHub issue 196 for more details.

--- a/client/vm.go
+++ b/client/vm.go
@@ -416,7 +416,11 @@ func (c *Client) DeleteVm(id string) error {
 	params := map[string]interface{}{
 		"id": id,
 	}
-	var reply []interface{}
+	// Xen Orchestra versions >= 5.x.x changed this return value to a bool
+	// when older versions returned an object. This needs to be an interface
+	// type in order to be backwards compatible while fixing this bug. See
+	// GitHub issue 196 for more details.
+	var reply interface{}
 	return c.Call("vm.delete", params, &reply)
 }
 


### PR DESCRIPTION
This addresses #196 

# Testing done
- [x] VM acceptance tests pass on XO v5.93.0
- [x] VM acceptance tests pass on XO v5.71.2
