### PR TITLE
Fix cloud config issue related to breaking change in XO api

### DIFF
--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -86,7 +86,11 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 		"name":     name,
 		"template": template,
 	}
-	var resp bool
+	// Xen Orchestra versions >= 5.98.0 changed this return value to a bool
+	// when older versions returned an object. This needs to be an interface
+	// type in order to be backwards compatible while fixing this bug. See
+	// GitHub issue 196 for more details.
+	var resp interface{}
 	err := c.Call("cloudConfig.create", params, &resp)
 
 	if err != nil {

--- a/client/cloud_config.go
+++ b/client/cloud_config.go
@@ -86,10 +86,10 @@ func (c *Client) CreateCloudConfig(name, template string) (*CloudConfig, error) 
 		"name":     name,
 		"template": template,
 	}
-	// Xen Orchestra versions >= 5.98.0 changed this return value to a bool
-	// when older versions returned an object. This needs to be an interface
+	// Xen Orchestra versions >= 5.98.0 changed this return value to an object
+	// when older versions returned bool. This needs to be an interface
 	// type in order to be backwards compatible while fixing this bug. See
-	// GitHub issue 196 for more details.
+	// GitHub issue 204 for more details.
 	var resp interface{}
 	err := c.Call("cloudConfig.create", params, &resp)
 


### PR DESCRIPTION
This fixes #204. It seems to be the result of the `cloudConfig.create` call and not the deletion.

## Testing
- [x] Cloud config acceptance tests pass against latest XO
- [x]  Cloud config acceptance tests pass against XO server version < 5.96.0
```
ddelnano@ddelnano-desktop:~/go/src/github.com/ddelnano/terraform-provider-xenorchestra$  TEST=TestAccXenorchestraCloudConfig make testacc

[ ... ]

=== RUN   TestAccXenorchestraCloudConfig_readAfterDelete
--- PASS: TestAccXenorchestraCloudConfig_readAfterDelete (2.32s)
=== RUN   TestAccXenorchestraCloudConfig_create
--- PASS: TestAccXenorchestraCloudConfig_create (1.19s)
=== RUN   TestAccXenorchestraCloudConfig_updateName
--- PASS: TestAccXenorchestraCloudConfig_updateName (2.21s)
=== RUN   TestAccXenorchestraCloudConfig_updateTemplate
--- PASS: TestAccXenorchestraCloudConfig_updateTemplate (2.00s)
=== RUN   TestAccXenorchestraCloudConfig_import
--- PASS: TestAccXenorchestraCloudConfig_import (1.35s)
PASS
[DEBUG] Running sweeper
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa 9.660s
testing: warning: no tests to run
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal        0.011s [no tests to run]

```