### PR TITLE
Update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ builds:
   ignore:
     - goarch: '386'
     - goarm: '6'
-    - goos: windows
+    - goos: windows # This can be removed once we are using > go 1.17 (https://goreleaser.com/deprecations/#builds-for-windowsarm64)
       goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
   ignore:
     - goarch: '386'
     - goarm: '6'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Until we move to go 1.17 this will need to be skipped ([goreleaser docs](https://goreleaser.com/deprecations/#builds-for-windowsarm64))