### PR TITLE
Shutdown VMs before destroying them

### DIFF
--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -836,10 +836,19 @@ func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
 	vmReq := client.Vm{
 		Id: d.Id(),
 	}
-	err := c.HaltVm(vmReq)
+
+	vm, err := c.GetVm(vmReq)
 	if err != nil {
 		return err
 	}
+
+	if vm.PowerState == "Running" {
+		err = c.HaltVm(vmReq)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = c.DeleteVm(d.Id())
 	if err != nil {
 		return err

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -833,8 +833,14 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
-	err := c.DeleteVm(d.Id())
-
+	vmReq := client.Vm{
+		Id: d.Id(),
+	}
+	err := c.HaltVm(vmReq)
+	if err != nil {
+		return err
+	}
+	err = c.DeleteVm(d.Id())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of simply terminating the vm without any warning, this tries to shut down the vm first.
This allows the VM to terminate its work properly.

Because of how `client.HaltVm()` is implemented, this has a not configurable 2 minutes timeout
See: https://github.com/terra-farm/terraform-provider-xenorchestra/blob/master/client/vm.go#L410