### PR TITLE
Remove version constraint on provider declaration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,6 @@ terraform {
   required_providers {
     xenorchestra = {
       source = "terra-farm/xenorchestra"
-      version = "~> 0.3.0"
     }
   }
 }


### PR DESCRIPTION
The provided example for terraform 0.13 include a constraint on version 0.3.0 which is very old (eg. no network data source). Removing this constraint allow the always use latest features.