### PR TITLE
Fix XO client issues that caused obscure test failures

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -22,7 +22,7 @@ func (net Network) Compare(obj interface{}) bool {
 	}
 
 	labelsMatch := false
-	if net.NameLabel == otherNet.NameLabel {
+	if net.NameLabel != "" && net.NameLabel == otherNet.NameLabel {
 		labelsMatch = true
 	}
 
@@ -133,6 +133,11 @@ func FindNetworkForTests(poolId string, network *Network) {
 		PoolId:    poolId,
 		NameLabel: netName,
 	})
+
+	if err != nil {
+		fmt.Printf("[ERROR] Failed to get network with error: %v", err)
+		os.Exit(1)
+	}
 
 	*network = *net
 }

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -15,11 +16,12 @@ func CreateResourceSet(rs ResourceSet) error {
 	return err
 }
 
-func CreateNetwork(network *Network) error {
+func CreateNetwork(network *Network) {
 	c, err := NewClient(GetConfigFromEnv())
 
 	if err != nil {
-		return err
+		fmt.Printf("[ERROR] Failed to create network with '%v'\n", err)
+		os.Exit(1)
 	}
 
 	net, err := c.CreateNetwork(Network{
@@ -28,10 +30,10 @@ func CreateNetwork(network *Network) error {
 	})
 
 	if err != nil {
-		return err
+		fmt.Printf("[ERROR] Failed to create network with '%v'\n", err)
+		os.Exit(1)
 	}
 	*network = *net
-	return nil
 }
 
 var integrationTestPrefix string = "xenorchestra-client-"

--- a/client/vif_test.go
+++ b/client/vif_test.go
@@ -73,7 +73,7 @@ func TestCreateVIF_DeleteVIF(t *testing.T) {
 		t.Fatalf("failed to create client with error: %v", err)
 	}
 
-	vm, err := c.GetVm(accVm)
+	vm, err := c.GetVm(Vm{Id: accVm.Id})
 
 	if err != nil {
 		t.Fatalf("failed to get VM with error: %v", err)

--- a/client/vm.go
+++ b/client/vm.go
@@ -213,7 +213,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"bootAfterCreate":  true,
 		"name_label":       vmReq.NameLabel,
 		"name_description": vmReq.NameDescription,
-		"hvmBootFirmware":  vmReq.Boot.Firmware,
 		"template":         vmReq.Template,
 		"coreOs":           false,
 		"cpuCap":           nil,
@@ -232,6 +231,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	videoram := vmReq.Videoram.Value
 	if videoram != 0 {
 		params["videoram"] = videoram
+	}
+
+	firmware := vmReq.Boot.Firmware
+	if firmware != "" {
+		params["hvmBootFirmware"] = firmware
 	}
 
 	vga := vmReq.Vga
@@ -311,15 +315,12 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		"affinityHost":      vmReq.AffinityHost,
 		"name_label":        vmReq.NameLabel,
 		"name_description":  vmReq.NameDescription,
-		"hvmBootFirmware":   vmReq.Boot.Firmware,
 		"auto_poweron":      vmReq.AutoPoweron,
 		"high_availability": vmReq.HA, // valid options are best-effort, restart, ''
 		"CPUs":              vmReq.CPUs.Number,
 		"memoryMax":         vmReq.Memory.Static[1],
 		"expNestedHvm":      vmReq.ExpNestedHvm,
 		"startDelay":        vmReq.StartDelay,
-		"vga":               vmReq.Vga,
-		"videoram":          vmReq.Videoram.Value,
 		// TODO: These need more investigation before they are implemented
 		// pv_args
 
@@ -333,8 +334,18 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
 	}
 
+	videoram := vmReq.Videoram.Value
+	if videoram != 0 {
+		params["videoram"] = videoram
+	}
+
 	if vmReq.ResourceSet != nil {
 		params["resourceSet"] = vmReq.ResourceSet
+	}
+
+	vga := vmReq.Vga
+	if vga != "" {
+		params["vga"] = vga
 	}
 
 	// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
@@ -342,6 +353,11 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 	// if secureBoot {
 	// 	params["secureBoot"] = true
 	// }
+
+	firmware := vmReq.Boot.Firmware
+	if firmware != "" {
+		params["hvmBootFirmware"] = firmware
+	}
 
 	blockedOperations := map[string]interface{}{}
 	for k, v := range vmReq.BlockedOperations {

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -245,10 +245,22 @@ func TestUpdateVmWithUpdatesThatRequireHalt(t *testing.T) {
 
 	prevCPUs := accVm.CPUs.Number
 	updatedCPUs := prevCPUs + 1
+	err = c.HaltVm(Vm{Id: accVm.Id})
+
+	if err != nil {
+		t.Fatalf("failed to halt vm ahead of update: %v", err)
+	}
+
 	vm, err := c.UpdateVm(Vm{Id: accVm.Id, CPUs: CPUs{Number: updatedCPUs}, NameLabel: "terraform testing", Memory: MemoryObject{Static: []int{0, 4294967296}}})
 
 	if err != nil {
 		t.Fatalf("failed to update vm with error: %v", err)
+	}
+
+	err = c.StartVm(vm.Id)
+
+	if err != nil {
+		t.Fatalf("failed to start vm after update: %v", err)
 	}
 
 	if vm.CPUs.Number != updatedCPUs {

--- a/xoa/data_source_xenorchestra_network_test.go
+++ b/xoa/data_source_xenorchestra_network_test.go
@@ -19,7 +19,11 @@ var createNetwork = func(net client.Network, t *testing.T, times int) func() {
 				t.Fatalf("failed to created client with error: %v", err)
 			}
 
-			c.CreateNetwork(net)
+			_, err = c.CreateNetwork(net)
+
+			if err != nil {
+				t.Fatalf("failed to created network with error: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The client package had a variety of issues that caused flaky tests and resulted in obscure failures that were difficult to debug due to lack of error handling.

This PR addresses those issues and verifies that master is in a passing state again. I'm working to improve the test suite quality and setup CI (see #188 for some historical context). This change was run under the test runner I am to use (`gotestrun`) and was successful.