### PR TITLE
Improve quality of the terraform acc test suite by rerunning tests with `gotestsum`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: import testacc testclient test dist
 
+# TODO(ddelnano|): Changes to gotestsum must be upstreamed to handle panic'ed tests.
+# Until clone https://github.com/ddelnano/gotestsum and build the binary yourself.
+GOTESTSUM_BIN ?= ~/code/gotestsum/gotestsum
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
 ifdef TEST
@@ -38,3 +41,6 @@ testclient:
 
 testacc: sweep
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT)
+
+ci:
+	TF_ACC=1 $(GOTESTSUM_BIN) --rerun-fails=3 --rerun-fails-max-failures=1000 --packages='./...' -- ./... -parallel $(GOMAXPROCS) -v -count=1 -timeout=$(TIMEOUT) -sweep=true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: import testacc testclient test dist
 
 # TODO(ddelnano|#218): Changes to gotestsum must be upstreamed to handle panic'ed tests.
-# Until clone https://github.com/ddelnano/gotestsum and build the binary yourself.
+# Until then clone https://github.com/ddelnano/gotestsum and build the binary yourself.
 GOTESTSUM_BIN ?= ~/code/gotestsum/gotestsum
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: import testacc testclient test dist
 
-# TODO(ddelnano|): Changes to gotestsum must be upstreamed to handle panic'ed tests.
+# TODO(ddelnano|#218): Changes to gotestsum must be upstreamed to handle panic'ed tests.
 # Until clone https://github.com/ddelnano/gotestsum and build the binary yourself.
 GOTESTSUM_BIN ?= ~/code/gotestsum/gotestsum
 TIMEOUT ?= 40m

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -30,30 +30,29 @@ func TestMain(m *testing.M) {
 
 	if flagSweep != nil && flagSweep.Value.String() != "" {
 		resource.TestMain(m)
-	} else {
-		_, runSetup := os.LookupEnv("TF_ACC")
-
-		if runSetup {
-			client.FindPoolForTests(&accTestPool)
-			client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
-			client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
-			client.FindHostForTests(accTestPool.Master, &accTestHost)
-			client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
-			client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
-			client.CreateUser(&accUser)
-			testIsoName = os.Getenv("XOA_ISO")
-		}
-
-		code := m.Run()
-
-		if runSetup {
-			client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
-			client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
-			client.RemoveTagFromAllObjects(accTestPrefix)("")
-			client.RemoveUsersWithPrefix(accTestPrefix)("")
-			client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
-		}
-
-		os.Exit(code)
 	}
+	_, runSetup := os.LookupEnv("TF_ACC")
+
+	if runSetup {
+		client.FindPoolForTests(&accTestPool)
+		client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
+		client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
+		client.FindHostForTests(accTestPool.Master, &accTestHost)
+		client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
+		client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
+		client.CreateUser(&accUser)
+		testIsoName = os.Getenv("XOA_ISO")
+	}
+
+	code := m.Run()
+
+	if runSetup {
+		client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
+		client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
+		client.RemoveTagFromAllObjects(accTestPrefix)("")
+		client.RemoveUsersWithPrefix(accTestPrefix)("")
+		client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
+	}
+
+	os.Exit(code)
 }


### PR DESCRIPTION
This addresses #188 

## Testing
- [x] Verified that triggering `go test` timeouts results in gotestsum retrying failed tests (performed [here](https://github.com/terra-farm/terraform-provider-xenorchestra/issues/188#issuecomment-1341719941))
- [x] Verified that `make ci` results in a successful build
```
ddelnano@ddelnano-desktop:~/go/src/github.com/ddelnano/terraform-provider-xenorchestra$ make ci
TF_ACC=1 ~/code/gotestsum/gotestsum --rerun-fails=3 --rerun-fails-max-failures=1000 --packages='./...' -- ./... -parallel 5 -v -count=1 -timeout=40m -sweep=true
∅  .
✓  xoa/internal (14ms)
✖  xoa (28m51.65s)

DONE 86 tests, 1 skipped, 1 failure in 1732.939s

∅  .
✓  xoa/internal (41ms)
✓  xoa (52.618s)

=== Skipped
=== SKIP: xoa TestAccXenorchestraVm_createVmThatInstallsFromTheNetwork (0.00s)
    resource_xenorchestra_vm_test.go:461: For now this test is not implemented. See #156 for more details

=== Failed
=== FAIL: xoa TestAccXenorchestraVm_createWithShorterResourceTimeout (100.38s)
    resource_xenorchestra_vm_test.go:329: Step 1/1, expected an error but got none

DONE 2 runs, 87 tests, 1 skipped, 1 failure in 1787.366s
ddelnano@ddelnano-desktop:~/go/src/github.com/ddelnano/terraform-provider-xenorchestra$ echo $?
0
```