### PR TITLE
Add warning log message when cloud config is malformed (missing required string).

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -265,6 +265,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 
 	cloudConfig := vmReq.CloudConfig
 	if cloudConfig != "" {
+		if !strings.HasPrefix(cloudConfig, "#cloud-config") {
+			log.Printf("[WARNING] cloud config does not start with required text `#cloud-config`.")
+			log.Printf("[WARNING] Validate that your configuration is well formed according to the documentation (https://cloudinit.readthedocs.io/en/latest/topics/format.html).\n")
+		}
+
 		params["cloudConfig"] = cloudConfig
 	}
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -82,7 +82,7 @@ This does not work in terraform since that is applied on Xen Orchestra's client 
 * `name_label` - (Required) The name of VM.
 * `name_description` - (Optional) The description of the VM.
 * `template` - (Required) The ID of the VM template to create the new VM from.
-* `cloud_config` - (Optional) The content of the cloud-init config to use
+* `cloud_config` - (Optional) The content of the cloud-init config to use. See the cloud init docs for more [information](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
 * `cloud_network_config` - (Optional) The content of the cloud-init network configuration for the VM (uses [version 1](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html))
 * `cpus` - (Required) The number of CPUs the VM will have. Updates to this field will cause a stop and start of the VM if the new CPU value is greater than the max CPU value. This can be determined with the following command:
 ```


### PR DESCRIPTION
This PR is meant to address #202.

I don't think the XO provider should provide bulletproof validation when there is an official [data source](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) for cloudinit, but hopefully this should catch very obvious errors in the cloud config.

## Testing
- [x] Existing test suite triggers new logging when running a VM test (all cloud config used in the acceptance tests is malformed and will trigger this new check)
```
ddelnano@ddelnano-desktop:~/go/src/github.com/ddelnano/terraform-provider-xenorchestra$ TEST=TestAccXenorchestraVm_createWithMutipleDisks TF_LOG=trace make testacc 2>&1 | grep WARNING
2022/12/12 16:45:35 [WARNING] cloud config does not start with required text `#cloud-config`.
2022/12/12 16:45:35 [WARNING] Validate that your configuration is well formed according to the documentation (https://cloudinit.readthedocs.io/en/latest/topics/format.html).
2022/12/12 16:46:54 [WARNING] cloud config does not start with required text `#cloud-config`.
2022/12/12 16:46:54 [WARNING] Validate that your configuration is well formed according to the documentation (https://cloudinit.readthedocs.io/en/latest/topics/format.html).

```