### PR TITLE
Improve XO client's handling of VM shutdown

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -32,7 +32,7 @@ type XOClient interface {
 	GetVms(vm Vm) ([]Vm, error)
 	UpdateVm(vmReq Vm) (*Vm, error)
 	DeleteVm(id string) error
-	HaltVm(vmReq Vm) error
+	HaltVm(id string) error
 	StartVm(id string) error
 
 	GetCloudConfigByName(name string) ([]CloudConfig, error)

--- a/client/vm.go
+++ b/client/vm.go
@@ -409,6 +409,9 @@ func (c *Client) StartVm(id string) error {
 }
 
 func (c *Client) HaltVm(id string) error {
+	// PV drivers are necessary for the XO api to issue a graceful shutdown.
+	// See https://github.com/terra-farm/terraform-provider-xenorchestra/issues/220
+	// for more details.
 	if err := c.waitForManagementAgentDetected(id); err != nil {
 		return errors.New(
 			fmt.Sprintf("failed to gracefully halt the vm with id: %s and error: %v", id, err))

--- a/client/vm.go
+++ b/client/vm.go
@@ -121,11 +121,12 @@ type Vm struct {
 	// These fields are used for passing in disk inputs when
 	// creating Vms, however, this is not a real field as far
 	// as the XO api or XAPI is concerned
-	Disks              []Disk              `json:"-"`
-	CloudNetworkConfig string              `json:"-"`
-	VIFsMap            []map[string]string `json:"-"`
-	WaitForIps         bool                `json:"-"`
-	Installation       Installation        `json:"-"`
+	Disks                   []Disk              `json:"-"`
+	CloudNetworkConfig      string              `json:"-"`
+	VIFsMap                 []map[string]string `json:"-"`
+	WaitForIps              bool                `json:"-"`
+	Installation            Installation        `json:"-"`
+	ManagementAgentDetected bool                `json:"managementAgentDetected"`
 }
 
 type Installation struct {
@@ -265,11 +266,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 
 	cloudConfig := vmReq.CloudConfig
 	if cloudConfig != "" {
-		if !strings.HasPrefix(cloudConfig, "#cloud-config") {
-			log.Printf("[WARNING] cloud config does not start with required text `#cloud-config`.")
-			log.Printf("[WARNING] Validate that your configuration is well formed according to the documentation (https://cloudinit.readthedocs.io/en/latest/topics/format.html).\n")
-		}
-
 		params["cloudConfig"] = cloudConfig
 	}
 
@@ -412,9 +408,14 @@ func (c *Client) StartVm(id string) error {
 	)
 }
 
-func (c *Client) HaltVm(vmReq Vm) error {
+func (c *Client) HaltVm(id string) error {
+	if err := c.waitForManagementAgentDetected(id); err != nil {
+		return errors.New(
+			fmt.Sprintf("failed to gracefully halt the vm with id: %s and error: %v", id, err))
+	}
+
 	params := map[string]interface{}{
-		"id": vmReq.Id,
+		"id": id,
 	}
 	var success bool
 	// TODO: This can block indefinitely before we get to the waitForVmHalt
@@ -424,7 +425,7 @@ func (c *Client) HaltVm(vmReq Vm) error {
 		return err
 	}
 	return c.waitForVmState(
-		vmReq.Id,
+		id,
 		StateChangeConf{
 			Pending: []string{"Running", "Stopped"},
 			Target:  []string{"Halted"},
@@ -493,6 +494,26 @@ func GetVmPowerState(c *Client, id string) func() (result interface{}, state str
 
 		return vm, vm.PowerState, nil
 	}
+}
+
+func (c *Client) waitForManagementAgentDetected(id string) error {
+	refreshFn := func() (result interface{}, state string, err error) {
+		vm, err := c.GetVm(Vm{Id: id})
+
+		if err != nil {
+			return vm, "", err
+		}
+
+		return vm, strconv.FormatBool(vm.ManagementAgentDetected), nil
+	}
+	stateConf := &StateChangeConf{
+		Pending: []string{"false"},
+		Refresh: refreshFn,
+		Target:  []string{"true"},
+		Timeout: 2 * time.Minute,
+	}
+	_, err := stateConf.WaitForState()
+	return err
 }
 
 func (c *Client) waitForVmState(id string, stateConf StateChangeConf) error {

--- a/client/vm_test.go
+++ b/client/vm_test.go
@@ -171,6 +171,9 @@ func TestUnmarshalingVmObject(t *testing.T) {
 		t.Fatalf("Expected vm to Unmarshal from numerical videoram value")
 	}
 
+	if vmObj.ManagementAgentDetected != false {
+		t.Fatalf("expected vm to Unmarshal to 'false' when `managementAgentDetected` not present")
+	}
 }
 
 func TestFlatResourceSetStringerInterface(t *testing.T) {
@@ -245,7 +248,7 @@ func TestUpdateVmWithUpdatesThatRequireHalt(t *testing.T) {
 
 	prevCPUs := accVm.CPUs.Number
 	updatedCPUs := prevCPUs + 1
-	err = c.HaltVm(Vm{Id: accVm.Id})
+	err = c.HaltVm(accVm.Id)
 
 	if err != nil {
 		t.Fatalf("failed to halt vm ahead of update: %v", err)

--- a/xoa/internal/mocks.go
+++ b/xoa/internal/mocks.go
@@ -14,7 +14,7 @@ type failToStartAndHaltVmXOClient struct {
 	*client.Client
 }
 
-func (c failToStartAndHaltVmXOClient) HaltVm(vmReq client.Vm) error {
+func (c failToStartAndHaltVmXOClient) HaltVm(id string) error {
 	return errors.New("This method shouldn't be called")
 }
 func (c failToStartAndHaltVmXOClient) StartVm(id string) error {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -785,7 +785,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		},
 	}
 	if haltForUpdates {
-		err := c.HaltVm(vmReq)
+		err := c.HaltVm(id)
 
 		if err != nil {
 			return err
@@ -833,8 +833,23 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceVmDelete(d *schema.ResourceData, m interface{}) error {
 	c := m.(client.XOClient)
 
-	err := c.DeleteVm(d.Id())
+	vmReq := client.Vm{
+		Id: d.Id(),
+	}
 
+	vm, err := c.GetVm(vmReq)
+	if err != nil {
+		return err
+	}
+
+	if vm.PowerState == "Running" {
+		err = c.HaltVm(vmReq.Id)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = c.DeleteVm(d.Id())
 	if err != nil {
 		return err
 	}

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1391,7 +1391,7 @@ func TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted(t *testing.
 			NameLabel: vmName,
 		})
 
-		err = c.HaltVm(*vm)
+		err = c.HaltVm(vm.Id)
 
 		if err != nil {
 			t.Fatalf("failed to halt VM with error: %v", err)


### PR DESCRIPTION
This addresses #220 and is a prerequisite to completing #212. See #220 for more details.

## Testing
- [x] `make testacc` passes
- [x] Verified that `TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted` fails on master when run individually (not as part of the larger test suite)
```
$  TEST=TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted make testacc

[ ... ]

    resource_xenorchestra_vm_test.go:1397: failed to halt VM with error: jsonrpc2: code 14 message: VM lacks feature : {"objectId":"195f07f5-c699-a270-3a31-a9eaafc54af3"}
--- FAIL: TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted (49.81s)

```
- [x] Verified that the `TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted` test can run in isolation after this change
```
$ TEST=TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted make testacc

[ ... ]

=== RUN   TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted
=== PAUSE TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted
=== CONT  TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted
--- PASS: TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted (105.49s)
PASS
[DEBUG] Running sweeper
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa 123.809s
testing: warning: no tests to run
PASS
ok      github.com/ddelnano/terraform-provider-xenorchestra/xoa/internal        0.012s [no tests to run]

```