### PR TITLE
Use the correct detection for if PV drivers are available

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -415,7 +415,7 @@ func (c *Client) HaltVm(id string) error {
 	// for more details.
 	if err := c.waitForPVDriversDetected(id); err != nil {
 		return errors.New(
-			fmt.Sprintf("failed to gracefully halt vm (%s) since PV drivers never detected", id))
+			fmt.Sprintf("failed to gracefully halt vm (%s) since PV drivers were never detected", id))
 	}
 
 	params := map[string]interface{}{


### PR DESCRIPTION
This is a fix on top of #220. The previous change relied on the management agent's presence, but we actually want to know if the VM has PV drivers available.

## Testing
- [x] `TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted` passes when it would fail prior to this improved graceful shutdown behavior
- [x] Verified that this is an accurate means of detecting PV drivers are available. Used the VM below as a reference.
![Screenshot_20221215_092540](https://user-images.githubusercontent.com/5855593/207927332-7f86a1e0-3a6d-4141-b4e5-abacbc03ed9e.png)
