### PR TITLE
Fix sending empty mac address to XO

### DIFF
--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -330,10 +330,18 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 	for _, network := range networks {
 		netMap, _ := network.(map[string]interface{})
 
-		network_maps = append(network_maps, map[string]string{
-			"network": netMap["network_id"].(string),
-			"mac":     getFormattedMac(netMap["mac_address"].(string)),
-		})
+		netID := netMap["network_id"].(string)
+		macAddr := netMap["mac_address"].(string)
+
+		netMapToAdd := map[string]string{
+			"network": netID,
+		}
+		// We only add the mac address if it contains a value.
+		if macAddr != "" {
+			netMapToAdd["mac"] = getFormattedMac(macAddr)
+		}
+
+		network_maps = append(network_maps, netMapToAdd)
 	}
 
 	ds := []client.Disk{}
@@ -1175,20 +1183,19 @@ type guestNetwork map[string][]string
 // of maps where each element represents a network interface.
 // Each map will contain the following keys: ip, ipv4 and ipv6. The values
 // will be a slice of ip addresses.
-// []map[string][]string{
-//   {
-//     "ip":   []string{"interface 1's IPs",
-//     "ipv4": []string{"interface 1's IPs",
-//     "ipv6": []string{"ip1", "ip2"}
-//   },
-//   {
-//     "ip":   []string{"interface 2's IPs",
-//     "ipv4": []string{"interface 2's IPs",
-//     "ipv6": []string{"ip1", "ip2"}
-//   },
-// }
 //
-//
+//	[]map[string][]string{
+//	  {
+//	    "ip":   []string{"interface 1's IPs",
+//	    "ipv4": []string{"interface 1's IPs",
+//	    "ipv6": []string{"ip1", "ip2"}
+//	  },
+//	  {
+//	    "ip":   []string{"interface 2's IPs",
+//	    "ipv4": []string{"interface 2's IPs",
+//	    "ipv6": []string{"ip1", "ip2"}
+//	  },
+//	}
 func extractIpsFromNetworks(networks map[string]string) []guestNetwork {
 
 	if len(networks) < 1 {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -230,6 +230,15 @@ func resourceVmSchema() map[string]*schema.Schema {
 						Type:     schema.TypeString,
 						Optional: true,
 						Computed: true,
+						StateFunc: func(val interface{}) string {
+							unformattedMac := val.(string)
+							mac, err := net.ParseMAC(unformattedMac)
+							if err != nil {
+								panic(fmt.Sprintf("Mac address `%s` was not parsable. This should never happened because Terraform's validation should happen before this is stored into state", unformattedMac))
+							}
+							return mac.String()
+
+						},
 						ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 							mac_address := val.(string)
 							if _, err := net.ParseMAC(mac_address); err != nil {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -230,15 +230,6 @@ func resourceVmSchema() map[string]*schema.Schema {
 						Type:     schema.TypeString,
 						Optional: true,
 						Computed: true,
-						StateFunc: func(val interface{}) string {
-							unformattedMac := val.(string)
-							mac, err := net.ParseMAC(unformattedMac)
-							if err != nil {
-								panic(fmt.Sprintf("Mac address `%s` was not parsable. This should never happened because Terraform's validation should happen before this is stored into state", unformattedMac))
-							}
-							return mac.String()
-
-						},
 						ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 							mac_address := val.(string)
 							if _, err := net.ParseMAC(mac_address); err != nil {


### PR DESCRIPTION
The XO api no longer allows for Mac addresses to be empty when creating nics for a VM. However it does accept not specifying the MAC in which case it generates the MAC like before.

This changes introduces a check for mac address being empty and only appends it to the map if it contains a value