### PR TITLE
Ensure `xenorchestra_vm` resource updates properly handle nullable XO api fields

### DIFF
--- a/client/vif.go
+++ b/client/vif.go
@@ -74,7 +74,9 @@ func (c *Client) CreateVIF(vm *Vm, vif *VIF) (*VIF, error) {
 	params := map[string]interface{}{
 		"network": vif.Network,
 		"vm":      vm.Id,
-		"mac":     vif.MacAddress,
+	}
+	if vif.MacAddress != "" {
+		params["mac"] = vif.MacAddress
 	}
 	err := c.Call("vm.createInterface", params, &id)
 

--- a/client/vm.go
+++ b/client/vm.go
@@ -95,7 +95,7 @@ type Vm struct {
 	Boot               Boot              `json:"boot,omitempty"`
 	Type               string            `json:"type,omitempty"`
 	Id                 string            `json:"id,omitempty"`
-	AffinityHost       string            `json:"affinityHost,omitempty"`
+	AffinityHost       *string           `json:"affinityHost,omitempty"`
 	NameDescription    string            `json:"name_description"`
 	NameLabel          string            `json:"name_label"`
 	CPUs               CPUs              `json:"CPUs"`
@@ -212,7 +212,6 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	}
 
 	params := map[string]interface{}{
-		"affinityHost":     vmReq.AffinityHost,
 		"bootAfterCreate":  true,
 		"name_label":       vmReq.NameLabel,
 		"name_description": vmReq.NameDescription,
@@ -239,6 +238,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	firmware := vmReq.Boot.Firmware
 	if firmware != "" {
 		params["hvmBootFirmware"] = firmware
+	}
+
+	affinityHost := vmReq.AffinityHost
+	if affinityHost != nil {
+		params["affinityHost"] = affinityHost
 	}
 
 	vga := vmReq.Vga

--- a/client/vm.go
+++ b/client/vm.go
@@ -321,7 +321,6 @@ func createVdiMap(disk Disk) map[string]interface{} {
 func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 	params := map[string]interface{}{
 		"id":                vmReq.Id,
-		"affinityHost":      vmReq.AffinityHost,
 		"name_label":        vmReq.NameLabel,
 		"name_description":  vmReq.NameDescription,
 		"auto_poweron":      vmReq.AutoPoweron,
@@ -341,6 +340,15 @@ func (c *Client) UpdateVm(vmReq Vm) (*Vm, error) {
 
 		// cpusMask, cpuWeight and cpuCap can be changed at runtime to an integer value or null
 		// coresPerSocket is null or a number of cores per socket. Putting an invalid value doesn't seem to cause an error :(
+	}
+
+	affinityHost := vmReq.AffinityHost
+	if affinityHost != nil {
+		if *affinityHost == "" {
+			params["affinityHost"] = nil
+		} else {
+			params["affinityHost"] = *affinityHost
+		}
 	}
 
 	videoram := vmReq.Videoram.Value

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -795,7 +795,7 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		},
 	}
 
-	if d.HasChange("affinity_host") && affinityHost != "" {
+	if d.HasChange("affinity_host") {
 		vmReq.AffinityHost = &affinityHost
 	}
 


### PR DESCRIPTION
This PR will address #238. At the moment it only fixes the issue for the `affinity_host` field, but this bug can manifest for any XO api string field.

This is a temporary solution as the XO client API code needs an overhaul to handle these in a cleaner way. That future refactor is in progress and will clean this up. However since this bug has present for months, this temporary fix will help in the meantime. 

## Todo
- [x] Handle remaining `xenorchestra_vm` resource fields that can be nullable -- issues with VIF creation were addressed in this as well.
- [x] Verified entire test suite passes