### PR TITLE
Ensure non default high availibility and autopoweron settings for VMs work

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -225,10 +225,12 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		"existingDisks":    existingDisks,
 		// TODO: (#145) Uncomment this once issues with secure_boot have been figured out
 		// "secureBoot":       vmReq.SecureBoot,
-		"expNestedHvm": vmReq.ExpNestedHvm,
-		"VDIs":         vdis,
-		"VIFs":         vmReq.VIFsMap,
-		"tags":         vmReq.Tags,
+		"expNestedHvm":      vmReq.ExpNestedHvm,
+		"VDIs":              vdis,
+		"VIFs":              vmReq.VIFsMap,
+		"tags":              vmReq.Tags,
+		"auto_poweron":      vmReq.AutoPoweron,
+		"high_availability": vmReq.HA,
 	}
 
 	videoram := vmReq.Videoram.Value

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -419,6 +419,8 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		Template:        d.Get("template").(string),
 		CloudConfig:     d.Get("cloud_config").(string),
 		ResourceSet:     rs,
+		HA:              d.Get("high_availability").(string),
+		AutoPoweron:     d.Get("auto_poweron").(bool),
 		CPUs: client.CPUs{
 			Number: d.Get("cpus").(int),
 		},

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1148,12 +1148,12 @@ func TestAccXenorchestraVm_updatesWithoutReboot(t *testing.T) {
 
 	origNameLabel := fmt.Sprintf("%s - orig label (%s)", accTestPrefix, t.Name())
 	origNameDesc := "name label"
-	origHa := ""
-	origPowerOn := false
+	origHa := "restart"
+	origPowerOn := true
 	updatedNameLabel := fmt.Sprintf("%s - updated label (%s)", accTestPrefix, t.Name())
 	updatedNameDesc := "Terraform Updated description"
-	updatedHa := "restart"
-	updatedPowerOn := true
+	updatedHa := ""
+	updatedPowerOn := false
 	affinityHost := accTestPool.Master
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
This is a continuation of #213 and fixes https://github.com/terra-farm/terraform-provider-xenorchestra/issues/209.

## Testing
- [x] New test fails on master but succeeds with client and `xenorchestra_vm` changes