### PR TITLE
Add `xenorchestra_network` example that was uncommitted

### DIFF
--- a/examples/resources/xenorchestra_network/resource.tf
+++ b/examples/resources/xenorchestra_network/resource.tf
@@ -1,0 +1,16 @@
+data "xenorchestra_host" "host1" {
+  name_label = "Your host"
+}
+
+data "xenorchestra_pif" "pif" {
+  device = "eth0"
+  vlan = -1
+  host_id = data.xenorchestra_host.host1.id
+}
+
+resource "xenorchestra_network" "network" {
+  name_label = "new network name"
+  pool_id = data.xenorchestra_host.host1.pool_id
+  pif_id = data.xenorchestra_pif.pif.id
+  vlan = 22
+}


### PR DESCRIPTION
This was part of adding the `xenorchestra_network` in #119. This example was included in the rendered documentation, but was accidentally uncommitted.