### PR TITLE
Introduce `source_pif_device` (replacement for `pif_id`) to better match TF's mental model fix import issues

### DIFF
--- a/client/pif.go
+++ b/client/pif.go
@@ -20,8 +20,12 @@ type PIF struct {
 func (p PIF) Compare(obj interface{}) bool {
 	otherPif := obj.(PIF)
 
-	if p.Id != "" && otherPif.Id == p.Id {
-		return true
+	if p.Id != "" {
+		if otherPif.Id == p.Id {
+			return true
+		} else {
+			return false
+		}
 	}
 	hostIdExists := p.Host != ""
 	if hostIdExists && p.Host != otherPif.Host {

--- a/client/pif.go
+++ b/client/pif.go
@@ -28,7 +28,12 @@ func (p PIF) Compare(obj interface{}) bool {
 		return false
 	}
 
-	if p.Vlan == otherPif.Vlan && p.Device == otherPif.Device {
+	networkIdExists := p.Network != ""
+	if networkIdExists && p.Network != otherPif.Network {
+		return false
+	}
+
+	if p.Vlan == otherPif.Vlan && (p.Device == "" || (p.Device == otherPif.Device)) {
 		return true
 	}
 	return false

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -17,16 +17,17 @@ data "xenorchestra_host" "host1" {
   name_label = "Your host"
 }
 
-data "xenorchestra_pif" "pif" {
-  device = "eth0"
-  vlan = -1
-  host_id = data.xenorchestra_host.host1.id
-}
-
-resource "xenorchestra_network" "network" {
+# Create a single server network private network
+resource "xenorchestra_network" "private_network" {
   name_label = "new network name"
   pool_id = data.xenorchestra_host.host1.pool_id
-  pif_id = data.xenorchestra_pif.pif.id
+}
+
+# Create a network with a 22 VLAN tag from the eth0 device
+resource "xenorchestra_network" "vlan_network" {
+  name_label = "new network name"
+  pool_id = data.xenorchestra_host.host1.pool_id
+  source_pif_device = "eth0"
   vlan = 22
 }
 ```
@@ -46,7 +47,7 @@ resource "xenorchestra_network" "network" {
 - `mtu` (Number) The MTU of the network. Defaults to `1500` if unspecified.
 - `name_description` (String)
 - `nbd` (Boolean) Whether the network should use a network block device. Defaults to `false` if unspecified.
-- `pif_id` (String) The pif (uuid) that should be used for this network.
+- `source_pif_device` (String) The PIF device (eth0, eth1, etc) that will be used as an input during network creation. This parameter is required if a vlan is specified.
 - `vlan` (Number) The vlan to use for the network. Defaults to `0` meaning no VLAN.
 
 ### Read-Only

--- a/examples/resources/xenorchestra_network/resource.tf
+++ b/examples/resources/xenorchestra_network/resource.tf
@@ -2,15 +2,16 @@ data "xenorchestra_host" "host1" {
   name_label = "Your host"
 }
 
-data "xenorchestra_pif" "pif" {
-  device = "eth0"
-  vlan = -1
-  host_id = data.xenorchestra_host.host1.id
-}
-
-resource "xenorchestra_network" "network" {
+# Create a single server network private network
+resource "xenorchestra_network" "private_network" {
   name_label = "new network name"
   pool_id = data.xenorchestra_host.host1.pool_id
-  pif_id = data.xenorchestra_pif.pif.id
+}
+
+# Create a network with a 22 VLAN tag from the eth0 device
+resource "xenorchestra_network" "vlan_network" {
+  name_label = "new network name"
+  pool_id = data.xenorchestra_host.host1.pool_id
+  source_pif_device = "eth0"
   vlan = 22
 }

--- a/xoa/resource_xenorchestra_network_test.go
+++ b/xoa/resource_xenorchestra_network_test.go
@@ -35,6 +35,42 @@ func TestAccXONetwork_create(t *testing.T) {
 	)
 }
 
+func TestAccXONetwork_import(t *testing.T) {
+	if accTestPIF.Id == "" {
+		t.Skip()
+	}
+	resourceName := "xenorchestra_network.network"
+	nameLabel := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	desc := "Non default description"
+	nbd := "false"
+	mtu := "1500"
+	vlan := "23"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccXenorchestraNetworkConfigNonDefaultsWithVlan(nameLabel, desc, mtu, nbd, vlan),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckXenorchestraNetwork(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name_label"),
+					resource.TestCheckResourceAttrSet(resourceName, "name_description"),
+					resource.TestCheckResourceAttrSet(resourceName, "pool_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "mtu"),
+					resource.TestCheckResourceAttrSet(resourceName, "source_pif_device"),
+					resource.TestCheckResourceAttrSet(resourceName, "vlan")),
+			},
+		},
+	},
+	)
+}
+
 func TestAccXONetwork_createWithVlanRequiresPIF(t *testing.T) {
 	if accTestPIF.Id == "" {
 		t.Skip()
@@ -46,11 +82,11 @@ func TestAccXONetwork_createWithVlanRequiresPIF(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccXenorchestraNetworkConfigWithoutVlan(nameLabel),
-				ExpectError: regexp.MustCompile("all of `pif_id,vlan` must be specified"),
+				ExpectError: regexp.MustCompile("all of `source_pif_device,vlan` must be specified"),
 			},
 			{
 				Config:      testAccXenorchestraNetworkConfigWithoutPIF(nameLabel),
-				ExpectError: regexp.MustCompile("all of `pif_id,vlan` must be specified"),
+				ExpectError: regexp.MustCompile("all of `source_pif_device,vlan` must be specified"),
 			},
 		},
 	},
@@ -80,6 +116,7 @@ func TestAccXONetwork_createWithNonDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_description", desc),
 					resource.TestCheckResourceAttr(resourceName, "pool_id", accTestPIF.PoolId),
 					resource.TestCheckResourceAttr(resourceName, "mtu", mtu),
+					resource.TestCheckResourceAttrSet(resourceName, "source_pif_device"),
 					resource.TestCheckResourceAttr(resourceName, "vlan", vlan),
 					resource.TestCheckResourceAttr(resourceName, "nbd", nbd)),
 			},
@@ -205,7 +242,7 @@ var testAccXenorchestraNetworkConfigWithoutVlan = func(name string) string {
 resource "xenorchestra_network" "network" {
     name_label = "%s"
     pool_id = "%s"
-    pif_id = data.xenorchestra_pif.pif.id
+    source_pif_device = "eth1"
 }
 `, name, accTestPIF.PoolId)
 }
@@ -234,22 +271,16 @@ resource "xenorchestra_network" "network" {
 
 var testAccXenorchestraNetworkConfigNonDefaultsWithVlan = func(name, desc, mtu, nbd, vlan string) string {
 	return fmt.Sprintf(`
-data "xenorchestra_pif" "pif" {
-    device = "eth0"
-    vlan = -1
-    host_id = "%s"
-}
-
 resource "xenorchestra_network" "network" {
     name_label = "%s"
     name_description = "%s"
     pool_id = "%s"
     mtu = %s
     nbd = %s
-    pif_id = data.xenorchestra_pif.pif.id
+    source_pif_device = "eth0"
     vlan = %s
 }
-`, accTestPIF.Host, name, desc, accTestPIF.PoolId, mtu, nbd, vlan)
+`, name, desc, accTestPIF.PoolId, mtu, nbd, vlan)
 }
 
 var testAccXenorchestraNetworkConfigInPlaceUpdates = func(name, desc, nbd, automatic, isLocked string) string {


### PR DESCRIPTION
This PR introduce a `source_pif_device` argument (replacement for `pif_id`) to the `xenorchestra_network` resource to better match Terraform's mental model and fix the import issues reported in #257.

The issue with the previous resource was that the `pif_id` could not be determined once a network was created (a network's PIFs change as hosts are added to the pool). Rather than directly expose what the XO api requires (a pif id), this PR adds a "source device" argument, which can always be determined even after a network was created. In addition to fixing #257, this means that if a network was `terraform destroy && terraform apply`ed the network would be recreated properly.

## Testing done
- [x] New import test verifies that the issues experienced in #257 will not occur
- [x] Verify the acceptance test suite passes