### PR TITLE
Add exponential backoff for requests that receive PV drivers missing error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -237,7 +237,7 @@ func IsRetryableError(err jsonrpc2.Error) bool {
 	// making XO api calls during this time can return a VM_MISSING_PV_DRIVERS error. These errors can
 	// be treated as retryable since we want to wait until the VM has finished booting and its PV driver
 	// is initialized.
-	if err.Code == 11 {
+	if err.Code == 11 || err.Code == 14 {
 		return true
 	}
 	return false

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,5 +50,7 @@ provider "xenorchestra" {
 
 - `insecure` (Boolean) Whether SSL should be verified or not. Can be set via the XOA_INSECURE environment variable.
 - `password` (String) Password for xoa api. Can be set via the XOA_PASSWORD environment variable.
+- `retry_max_time` (String) If `retry_mode` is set, this specifies the duration for which the backoff method will continue retries. Can be set via the `XOA_RETRY_MAX_TIME` environment variable
+- `retry_mode` (String) Specifies if retries should be attempted for requests that require eventual . Can be set via the XOA_RETRY_MODE environment variable.
 - `url` (String) Hostname of the xoa router. Can be set via the XOA_URL environment variable.
 - `username` (String) User account for xoa api. Can be set via the XOA_USER environment variable.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ddelnano/terraform-provider-xenorchestra
 go 1.16
 
 require (
+	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/ddelnano/terraform-provider-xenorchestra/client v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
+github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
Summary: Add exponential backoff for requests that receive PV drivers missing error

This PR is aimed at fixing some issues seen when running the acceptance test suite in Jenkins. There are times where an acceptance test that performs hot plugging of devices tries to attach or disconnect devices before the guest's has fully booted and had its PV drivers initialized.

In order to address this, the XO client has been augmented to provide a mechanism for retrying specific JSON rpc error codes and opting the "missing PV drivers" condition into this behavior.

Testing done:
- [x] Verified that multiple CI job runs succeeded with this change. This was validated with adhoc runs, but will be tested a final time from a Jenkins job.