### PR TITLE
Ensure all invocations of XO client creation provide retry parameters

### DIFF
--- a/xoa/internal/mocks.go
+++ b/xoa/internal/mocks.go
@@ -34,15 +34,5 @@ func newFailToStartAndHaltClient(config client.Config) (client.XOClient, error) 
 }
 
 func GetFailToStartAndHaltXOClient(d *schema.ResourceData) (interface{}, error) {
-	url := d.Get("url").(string)
-	username := d.Get("username").(string)
-	password := d.Get("password").(string)
-	insecure := d.Get("insecure").(bool)
-	config := client.Config{
-		Url:                url,
-		Username:           username,
-		Password:           password,
-		InsecureSkipVerify: insecure,
-	}
-	return newFailToStartAndHaltClient(config)
+	return newFailToStartAndHaltClient(client.GetConfigFromEnv())
 }

--- a/xoa/provider_test.go
+++ b/xoa/provider_test.go
@@ -52,4 +52,10 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("XOA_ISO_SR"); v == "" {
 		t.Fatal("The XOA_ISO_SR environment variable must be set")
 	}
+	if v := os.Getenv("XOA_RETRY_MAX_TIME"); v == "" {
+		t.Fatal("The XOA_RETRY_MAX_TIME environment variable must be set")
+	}
+	if v := os.Getenv("XOA_RETRY_MODE"); v == "" {
+		t.Fatal("The XOA_RETRY_MODE environment variable must be set")
+	}
 }


### PR DESCRIPTION
Summary: Ensure all invocations of XO client creation provide retry parameters

This is an extension of #262 and gets things one step closer to having master builds for #264 working. In the previous PR, I missed that there were a few additional invocations of XO client creation that were missing the new retry parameters. This caused the build to have a single flaky test since that client was used exclusively for it.

Testing done: Verified that Jenkins build became stable after this change