### PR TITLE
Run sweeper unconditionally on acc test runs and add CI Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,7 @@ test: testclient testacc
 testclient:
 	cd client; go test $(TEST) -v -count 1
 
-testacc: sweep
-	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT)
+testacc:
+	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT) -sweep=true
+ci:
+	TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)

--- a/client/client.go
+++ b/client/client.go
@@ -275,7 +275,6 @@ func NewClient(config Config) (XOClient, error) {
 
 func (c *Client) IsRetryableError(err jsonrpc2.Error) bool {
 
-	fmt.Printf("[ERROR] retry mode: %d and timeout %v, Handling jsonrpc2: %v\n", c.RetryMode, c.RetryMaxTime, err)
 	if c.RetryMode == None {
 		return false
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -275,6 +275,7 @@ func NewClient(config Config) (XOClient, error) {
 
 func (c *Client) IsRetryableError(err jsonrpc2.Error) bool {
 
+	fmt.Printf("[ERROR] retry mode: %d and timeout %v, Handling jsonrpc2: %v\n", c.RetryMode, c.RetryMaxTime, err)
 	if c.RetryMode == None {
 		return false
 	}

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -27,38 +27,37 @@ func TestMain(m *testing.M) {
 	// This leverages the existing flag defined in the terraform-plugin-sdk
 	// repo defined below
 	// https://github.com/hashicorp/terraform-plugin-sdk/blob/2c03a32a9d1be63a12eb18aaf12d2c5270c42346/helper/resource/testing.go#L58
-        flag.Parse()
-        flagSweep := flag.Lookup("sweep")
+	flag.Parse()
+	flagSweep := flag.Lookup("sweep")
 
 	if flagSweep != nil && flagSweep.Value.String() != "" {
-	        _, runSetup := os.LookupEnv("TF_ACC")
+		_, runSetup := os.LookupEnv("TF_ACC")
 
-	        if runSetup {
-	        	fmt.Println("Running sweeping")
-                        resource.TestMain(m)
+		if runSetup {
+			fmt.Println("Running sweeping")
+			resource.TestMain(m)
 
-	        	client.FindPoolForTests(&accTestPool)
-	        	client.FindPIFForTests(&accTestPIF)
-	        	client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
-	        	client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
-	        	client.FindHostForTests(accTestPool.Master, &accTestHost)
-	        	client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
-	        	client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
-	        	client.FindIsoStorageRepositoryForTests(accTestPool, &accIsoSr, accTestPrefix, "XOA_ISO_SR")
-	        	client.CreateUser(&accUser)
-	        	testIsoName = os.Getenv("XOA_ISO")
-	        	fmt.Printf("Found the following pool: %v sr: %v\n", accTestPool, accDefaultSr)
+			client.FindPoolForTests(&accTestPool)
+			client.FindPIFForTests(&accTestPIF)
+			client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
+			client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
+			client.FindHostForTests(accTestPool.Master, &accTestHost)
+			client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
+			client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
+			client.FindIsoStorageRepositoryForTests(accTestPool, &accIsoSr, accTestPrefix, "XOA_ISO_SR")
+			client.CreateUser(&accUser)
+			testIsoName = os.Getenv("XOA_ISO")
+			fmt.Printf("Found the following pool: %v sr: %v\n", accTestPool, accDefaultSr)
 
-	                code := m.Run()
-	        	client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
-	        	client.RemoveVDIsWithPrefix(accTestPrefix)("")
-	        	client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
-	        	client.RemoveTagFromAllObjects(accTestPrefix)("")
-	        	client.RemoveUsersWithPrefix(accTestPrefix)("")
-	        	client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
-	                os.Exit(code)
-                }
-        }
+			code := m.Run()
+			client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
+			client.RemoveVDIsWithPrefix(accTestPrefix)("")
+			client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
+			client.RemoveTagFromAllObjects(accTestPrefix)("")
+			client.RemoveUsersWithPrefix(accTestPrefix)("")
+			client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
+			os.Exit(code)
+		}
+	}
 
-	
 }

--- a/xoa/acc_setup_test.go
+++ b/xoa/acc_setup_test.go
@@ -27,38 +27,38 @@ func TestMain(m *testing.M) {
 	// This leverages the existing flag defined in the terraform-plugin-sdk
 	// repo defined below
 	// https://github.com/hashicorp/terraform-plugin-sdk/blob/2c03a32a9d1be63a12eb18aaf12d2c5270c42346/helper/resource/testing.go#L58
-	flag.Parse()
-	flagSweep := flag.Lookup("sweep")
+        flag.Parse()
+        flagSweep := flag.Lookup("sweep")
 
 	if flagSweep != nil && flagSweep.Value.String() != "" {
-		resource.TestMain(m)
-	} else {
-		_, runSetup := os.LookupEnv("TF_ACC")
+	        _, runSetup := os.LookupEnv("TF_ACC")
 
-		if runSetup {
-			client.FindPoolForTests(&accTestPool)
-			client.FindPIFForTests(&accTestPIF)
-			client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
-			client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
-			client.FindHostForTests(accTestPool.Master, &accTestHost)
-			client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
-			client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
-			client.FindIsoStorageRepositoryForTests(accTestPool, &accIsoSr, accTestPrefix, "XOA_ISO_SR")
-			client.CreateUser(&accUser)
-			testIsoName = os.Getenv("XOA_ISO")
-		}
+	        if runSetup {
+	        	fmt.Println("Running sweeping")
+                        resource.TestMain(m)
 
-		code := m.Run()
+	        	client.FindPoolForTests(&accTestPool)
+	        	client.FindPIFForTests(&accTestPIF)
+	        	client.FindTemplateForTests(&testTemplate, accTestPool.Id, "XOA_TEMPLATE")
+	        	client.FindTemplateForTests(&disklessTestTemplate, accTestPool.Id, "XOA_DISKLESS_TEMPLATE")
+	        	client.FindHostForTests(accTestPool.Master, &accTestHost)
+	        	client.FindNetworkForTests(accTestPool.Id, &accDefaultNetwork)
+	        	client.FindStorageRepositoryForTests(accTestPool, &accDefaultSr, accTestPrefix)
+	        	client.FindIsoStorageRepositoryForTests(accTestPool, &accIsoSr, accTestPrefix, "XOA_ISO_SR")
+	        	client.CreateUser(&accUser)
+	        	testIsoName = os.Getenv("XOA_ISO")
+	        	fmt.Printf("Found the following pool: %v sr: %v\n", accTestPool, accDefaultSr)
 
-		if runSetup {
-			client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
-			client.RemoveVDIsWithPrefix(accTestPrefix)("")
-			client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
-			client.RemoveTagFromAllObjects(accTestPrefix)("")
-			client.RemoveUsersWithPrefix(accTestPrefix)("")
-			client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
-		}
+	                code := m.Run()
+	        	client.RemoveNetworksWithNamePrefix(accTestPrefix)("")
+	        	client.RemoveVDIsWithPrefix(accTestPrefix)("")
+	        	client.RemoveResourceSetsWithNamePrefix(accTestPrefix)("")
+	        	client.RemoveTagFromAllObjects(accTestPrefix)("")
+	        	client.RemoveUsersWithPrefix(accTestPrefix)("")
+	        	client.RemoveCloudConfigsWithPrefix(accTestPrefix)("")
+	                os.Exit(code)
+                }
+        }
 
-		os.Exit(code)
-	}
+	
 }

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1130,7 +1130,7 @@ func TestAccXenorchestraVm_addVifAndRemoveVif(t *testing.T) {
 		CheckDestroy: testAccCheckXenorchestraVmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVmConfig(vmName),
+				Config: testAccVmConfigWithWaitForIp(vmName, "true"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -1694,6 +1694,10 @@ resource "xenorchestra_vm" "bar" {
 }
 
 func testAccVmConfig(vmName string) string {
+	return testAccVmConfigWithWaitForIp(vmName, "false")
+}
+
+func testAccVmConfigWithWaitForIp(vmName, waitForIp string) string {
 	return testAccCloudConfigConfig(fmt.Sprintf("vm-template-%s", vmName), "template") + testAccTemplateConfig() + fmt.Sprintf(`
 data "xenorchestra_network" "network" {
     name_label = "%s"
@@ -1716,8 +1720,9 @@ resource "xenorchestra_vm" "bar" {
       name_label = "disk 1"
       size = 10001317888
     }
+    wait_for_ip = %s
 }
-`, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, accDefaultSr.Id)
+`, accDefaultNetwork.NameLabel, accTestPool.Id, vmName, accDefaultSr.Id, waitForIp)
 }
 
 // This sets destroy_cloud_config_vdi_after_boot and wait_for_ip. The former is required for


### PR DESCRIPTION
Summary: Run sweeper unconditionally on acc test runs and add CI Makefile target

This change is the final step needed to get master builds stable for #264. Future work will be done to surface these build statuses, but for now having CI running nightly is a great first step. The other change bundled with opting the `TestAccXenorchestraVm_addVifAndRemoveVif` test into waiting for the VM's network interface to have an IP, which sped up the given test case.

Testing done: Jenkins build has been stable with these changes