### PR TITLE
Remove git lfs from the repo to avoid quota exhausted issues in CI build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-**/*.iso filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ main.tf
 terraform.tfstate*
 dist/
 vendor
+xoa/testdata/alpine-virt-3.17.0-x86_64.iso

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: import testacc testclient test dist
+.PHONY: import testacc testclient test dist ci
 
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
@@ -36,7 +36,12 @@ test: testclient testacc
 testclient:
 	cd client; go test $(TEST) -v -count 1
 
-testacc:
+testacc: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -parallel $(GOMAXPROCS) -v -count 1 -timeout $(TIMEOUT) -sweep=true
-ci:
+
+# This file was previously stored in the git repo with git lfs. GitHub
+# has a very low quota for number of allowed clones and so this needed
+# to be removed from the repo. Add a target to enforce that the CI system
+# has copied that file into place before the tests run
+ci: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
 	TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)


### PR DESCRIPTION
Summary: Remove git lfs from the repo to avoid quota exhausted issues in CI build

One of the provider acceptance tests requires an ISO file needed to test the `xenorchestra_vdi` resource. This was originally accomplished by putting the ISO file in git lfs. Now that Jenkins is running nightly builds, I noticed that GitHub has a special quota for these files and this repo has exhausted it's free limit. 

```
 > git checkout -f 9d5e64787ea2f2e36f0c4753f708ceb61a409017 # timeout=10
FATAL: Could not checkout 9d5e64787ea2f2e36f0c4753f708ceb61a409017
hudson.plugins.git.GitException: Command "git checkout -f 9d5e64787ea2f2e36f0c4753f708ceb61a409017" returned status code 128:
stdout: 
stderr: Downloading xoa/testdata/alpine-virt-3.17.0-x86_64.iso (51 MB)
Error downloading object: xoa/testdata/alpine-virt-3.17.0-x86_64.iso (8d4d53b): Smudge error: Error downloading xoa/testdata/alpine-virt-3.17.0-x86_64.iso (8d4d53bd34b2045e1e219b87887b0de8d217b6cd4a8b476a077429845a5582ba): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.

Errors logged to '/var/lib/jenkins/workspace/ddelnano-test/.git/lfs/logs/20231007T045602.255823267.log'.
Use `git lfs logs last` to view the log.
error: external filter 'git-lfs filter-process' failed
fatal: xoa/testdata/alpine-virt-3.17.0-x86_64.iso: smudge filter lfs failed
```

This change updates the dependent Makefile targets to fail if the file doesn't exist, and expects the CI system to provide this file in the expected location.

## Testing done
- [x] Jenkins build passes 