### PR TITLE
Upgrade the broken goreleaser GitHub action and all the other actions in use

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,13 +10,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20
       -
@@ -41,7 +41,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Summary: Upgrade the broken goreleaser GitHub action and all the other actions in use

The v0.25.1 [release failed](https://github.com/terra-farm/terraform-provider-xenorchestra/actions/runs/6465539070) to build due to the following error:
```
Annotations
1 warning
[goreleaser](https://github.com/terra-farm/terraform-provider-xenorchestra/actions/runs/6465539070/job/17551892888)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-go@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

This change upgrades goreleaser and all of the other GitHub actions to recent versions.

Testing done: Triggering the GitHub actions CI job and following up with another release build