### PR TITLE
Allow VM resource's `power_state` to be managed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -190,7 +190,7 @@ func GetConfigFromEnv() Config {
 		if err == nil {
 			retryMaxTime = duration
 		} else {
-			fmt.Println("[ERROR] failed to set retry mode, disabling retries\n")
+			fmt.Println("[ERROR] failed to set retry mode, disabling retries")
 		}
 	}
 	return Config{

--- a/client/client.go
+++ b/client/client.go
@@ -38,6 +38,8 @@ type XOClient interface {
 	DeleteVm(id string) error
 	HaltVm(id string) error
 	StartVm(id string) error
+	SuspendVm(id string) error
+	PauseVm(id string) error
 
 	GetCloudConfigByName(name string) ([]CloudConfig, error)
 	CreateCloudConfig(name, template string) (*CloudConfig, error)

--- a/client/vm.go
+++ b/client/vm.go
@@ -347,7 +347,7 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	}
 
 	bootAfterCreate := params["bootAfterCreate"].(bool)
-	if !bootAfterCreate {
+	if !bootAfterCreate && vmReq.PowerState == RunningPowerState {
 		err = c.StartVm(vmId)
 		if err != nil {
 			return nil, err

--- a/client/vm.go
+++ b/client/vm.go
@@ -182,6 +182,42 @@ func (v Vm) Compare(obj interface{}) bool {
 	return false
 }
 
+func (c *Client) SuspendVm(id string) error {
+	return c.changeVmState(id, "suspend", []string{SuspendedPowerState}, []string{RunningPowerState}, 2*time.Minute)
+}
+
+func (c *Client) changeVmState(id, action string, target, pending []string, timeout time.Duration) error {
+	// PV drivers are necessary for the XO api to issue a graceful shutdown.
+	// See https://github.com/terra-farm/terraform-provider-xenorchestra/issues/220
+	// for more details.
+	if err := c.waitForPVDriversDetected(id); err != nil {
+		return errors.New(
+			fmt.Sprintf("failed to gracefully %s vm (%s) since PV drivers were never detected", action, id))
+	}
+
+	params := map[string]interface{}{
+		"id": id,
+	}
+	var success bool
+	err := c.Call(fmt.Sprintf("vm.%s", action), params, &success)
+
+	if err != nil {
+		return err
+	}
+	return c.waitForVmState(
+		id,
+		StateChangeConf{
+			Pending: pending,
+			Target:  target,
+			Timeout: timeout,
+		},
+	)
+}
+
+func (c *Client) PauseVm(id string) error {
+	return c.changeVmState(id, "pause", []string{PausedPowerState}, []string{RunningPowerState}, 2*time.Minute)
+}
+
 func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	tmpl, err := c.GetTemplate(Template{
 		Id: vmReq.Template,
@@ -449,32 +485,7 @@ func (c *Client) StartVm(id string) error {
 }
 
 func (c *Client) HaltVm(id string) error {
-	// PV drivers are necessary for the XO api to issue a graceful shutdown.
-	// See https://github.com/terra-farm/terraform-provider-xenorchestra/issues/220
-	// for more details.
-	if err := c.waitForPVDriversDetected(id); err != nil {
-		return errors.New(
-			fmt.Sprintf("failed to gracefully halt vm (%s) since PV drivers were never detected", id))
-	}
-
-	params := map[string]interface{}{
-		"id": id,
-	}
-	var success bool
-	// TODO: This can block indefinitely before we get to the waitForVmHalt
-	err := c.Call("vm.stop", params, &success)
-
-	if err != nil {
-		return err
-	}
-	return c.waitForVmState(
-		id,
-		StateChangeConf{
-			Pending: []string{RunningPowerState},
-			Target:  []string{HaltedPowerState},
-			Timeout: 2 * time.Minute,
-		},
-	)
+	return c.changeVmState(id, "stop", []string{HaltedPowerState}, []string{RunningPowerState}, 2*time.Minute)
 }
 
 func (c *Client) DeleteVm(id string) error {

--- a/xoa/internal/state/migrate.go
+++ b/xoa/internal/state/migrate.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 
+	"github.com/ddelnano/terraform-provider-xenorchestra/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -355,7 +356,7 @@ func suppressAttachedDiffWhenHalted(k, old, new string, d *schema.ResourceData) 
 	powerState := d.Get("power_state").(string)
 	suppress = true
 
-	if powerState == "Running" {
+	if powerState == client.RunningPowerState {
 		suppress = false
 	}
 	log.Printf("[DEBUG] VM '%s' attribute has transitioned from '%s' to '%s' when PowerState '%s'. Suppress diff: %t", k, old, new, powerState, suppress)

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -35,10 +35,10 @@ var validFirmware = []string{
 }
 
 var validPowerState = []string{
-	"Running",
-	"Halted",
-	"Paused",
-	"Suspended",
+	client.HaltedPowerState,
+	client.PausedPowerState,
+	client.RunningPowerState,
+	client.SuspendedPowerState,
 }
 
 var validInstallationMethods = []string{
@@ -118,7 +118,7 @@ func resourceVmSchema() map[string]*schema.Schema {
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringInSlice(validPowerState, false),
 			Optional:     true,
-			Default:      "Running",
+			Default:      client.RunningPowerState,
 		},
 		"installation_method": &schema.Schema{
 			Type:          schema.TypeString,
@@ -909,13 +909,13 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] powerStateChanged=%t newPowerState=%s\n", powerStateChanged, newPowerState)
 	if haltForUpdates || powerStateChanged {
 		switch newPowerState {
-		case "Running":
+		case client.RunningPowerState:
 			err := c.StartVm(vmReq.Id)
 
 			if err != nil {
 				return err
 			}
-		case "Halted":
+		case client.HaltedPowerState:
 			if haltPerformed {
 				// Nothing here since we are already halted
 			} else {
@@ -1375,7 +1375,7 @@ func suppressAttachedDiffWhenHalted(k, old, new string, d *schema.ResourceData) 
 		log.Printf("[DEBUG] Power state has been changed\n")
 	}
 
-	if !ok && powerState == "Running" {
+	if !ok && powerState == client.RunningPowerState {
 		suppress = false
 	}
 	log.Printf("[DEBUG] VM '%s' attribute has transitioned from '%s' to '%s' when PowerState '%s'. Suppress diff: %t", k, old, new, powerState, suppress)

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -909,6 +909,18 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[DEBUG] powerStateChanged=%t newPowerState=%s\n", powerStateChanged, newPowerState)
 	if haltForUpdates || powerStateChanged {
 		switch newPowerState {
+		case client.PausedPowerState:
+			err := c.PauseVm(vmReq.Id)
+
+			if err != nil {
+				return err
+			}
+		case client.SuspendedPowerState:
+			err := c.SuspendVm(vmReq.Id)
+
+			if err != nil {
+				return err
+			}
 		case client.RunningPowerState:
 			err := c.StartVm(vmReq.Id)
 
@@ -916,10 +928,8 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 				return err
 			}
 		case client.HaltedPowerState:
-			if haltPerformed {
-				// Nothing here since we are already halted
-			} else {
-
+			// If the VM wasn't halted as part of the update, perform the halt now
+			if !haltPerformed {
 				err := c.HaltVm(id)
 
 				if err != nil {

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1500,7 +1500,7 @@ func TestAccXenorchestraVm_diskAndNetworkAttachmentIgnoredWhenHalted(t *testing.
 			},
 			{
 				PreConfig: shutdownVm,
-				Config:    testAccVmConfig(vmName),
+				Config:    testAccVmConfigWithPowerState(vmName, "Halted"),
 				PlanOnly:  true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccVmExists(resourceName),

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -375,6 +375,72 @@ func TestAccXenorchestraVm_createWithPowerStateChanges(t *testing.T) {
 	})
 }
 
+func TestAccXenorchestraVm_createAndSuspend(t *testing.T) {
+	resourceName := "xenorchestra_vm.bar"
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.RunningPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.RunningPowerState)),
+			},
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.SuspendedPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.SuspendedPowerState)),
+			},
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.RunningPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.RunningPowerState)),
+			},
+		},
+	})
+}
+
+func TestAccXenorchestraVm_createAndPause(t *testing.T) {
+	resourceName := "xenorchestra_vm.bar"
+	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.RunningPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.RunningPowerState)),
+			},
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.PausedPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.PausedPowerState)),
+			},
+			{
+				Config: testAccVmConfigWithPowerState(vmName, client.RunningPowerState),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", client.RunningPowerState)),
+			},
+		},
+	})
+}
+
 func TestAccXenorchestraVm_createAndPlanWithNonExistantVm(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -343,8 +343,8 @@ func TestAccXenorchestraVm_createWithShorterResourceTimeout(t *testing.T) {
 func TestAccXenorchestraVm_createWithPowerStateChanges(t *testing.T) {
 	resourceName := "xenorchestra_vm.bar"
 	vmName := fmt.Sprintf("%s - %s", accTestPrefix, t.Name())
-	runningPowerState := "Running"
-	stoppedPowerState := "Halted"
+	runningPowerState := client.RunningPowerState
+	stoppedPowerState := client.HaltedPowerState
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,


### PR DESCRIPTION
Summary: Allow VM resource's `power_state` to be managed

The VM resource's previous `power_state` attribute was computed and didn't allow for specifying the state as an input. This change implements the necessary support for creating VMs with a non default `power_state` and to manage the lifecycle of it as needed.

Testing Done: The following checks were successful
- [x] New tests verifies that the new functionality works as expected for creating and updating VMs
- [x] Acceptance tests pass 

Todo:
- [x] Clean up vm power state options (remove hardcoding) and remove bogus values ("Stopped" isn't a real state)
- [x] Add support for suspend and pause
- [x] Prevent `destroy_cloud_config_vdi_after_boot = true` and a non running `power_state` from being valid configuration