### PR TITLE
Add jenkins builds for pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
           steps {
             lock('xoa-test-runner') {
               sh 'cp /opt/terraform-provider-xenorchestra/testdata/images/alpine-virt-3.17.0-x86_64.iso xoa/testdata/alpine-virt-3.17.0-x86_64.iso'
-              sh 'make ci'
+              sh 'TF_VERSION=${TF_VERSION} make ci'
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 TIMEOUT ?= 40m
 GOMAXPROCS ?= 5
+TF_VERSION ?= v0.14.11
 ifdef TEST
     TEST := github.com/ddelnano/terraform-provider-xenorchestra/xoa -run '$(TEST)'
 else
@@ -44,4 +45,4 @@ testacc: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
 # to be removed from the repo. Add a target to enforce that the CI system
 # has copied that file into place before the tests run
 ci: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
-	TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)
+	TF_ACC_TERRAFORM_VERSION=$(TF_VERSION) TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)


### PR DESCRIPTION
Summary: Add jenkins builds for pull requests

This PR adds a Jenkinsfile that executes builds for all PRs. This partially completes #264.

The Jenkinsfile supports parameterizing the go version as well as the terraform versions to test against. At the moment, the test matrix (terraform versions) only supports Hashicorp's terraform. However, this can be extended to test against OpenTofu in the future.

The part of #264 that is missing is making the build status of a given commit and the logs available for the given PR. That will need additional investigation to complete. From my reading of the Jenkins GitHub branch source plugin and the GitHub commit status docs, it seems this must be accomplished through a GitHub app. These apps require callback URLs to setup authentication, so from my current research I believe it would require making Jenkins publicly available. That would  probably be a non starter, but more investigation needs to be done and alternatives need to be considered.

Testing done: Verified that the build executed against two terraform versions. The build didn't pass but it was due to a flaky issue and is not a real failure.

![screen](https://github.com/terra-farm/terraform-provider-xenorchestra/assets/5855593/12ab67a5-64e8-4822-a028-c137797b226b)


```
# Verify that the first build used v0.14.11 and second used v1.6.5
[root@jenkins-xoa ~]# ps auxww | grep terraform
jenkins   824996  0.0  1.1 764156 41640 ?        Sl   05:56   0:00 /tmp/plugintest-terraform59210296/terraform refresh -no-color -input=false -lock-timeout=0s -lock=true
jenkins   825003  0.0  1.3 764668 48596 ?        Sl   05:56   0:00 /tmp/plugintest-terraform59210296/terraform refresh -no-color -input=false -lock-timeout=0s -lock=true
root      825016  0.0  0.0  12144  1096 pts/0    S+   05:56   0:00 grep --color=auto terraform
[root@jenkins-xoa ~]# /tmp/plugintest-terraform59210296/terraform --version
Terraform v0.14.11


[root@jenkins-xoa ~]# ps auxww | grep terraform
jenkins   848814  0.0  1.6 1306828 60092 ?       Sl   06:25   0:00 /tmp/plugintest-terraform3788507395/terraform refresh -no-color -input=false -lock-timeout=0s -lock=true
root      848824  0.0  0.0  12144  1116 pts/0    S+   06:25   0:00 grep --color=auto terraform
[root@jenkins-xoa ~]# /tmp/plugintest-terraform3788507395/terraform --version
Terraform v1.6.5
on linux_amd64
```