### PR TITLE
Separate VM creation into create and start when possible

### DIFF
--- a/client/vm.go
+++ b/client/vm.go
@@ -213,7 +213,7 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	}
 
 	params := map[string]interface{}{
-		"bootAfterCreate":  true,
+		"bootAfterCreate":  false,
 		"name_label":       vmReq.NameLabel,
 		"name_description": vmReq.NameDescription,
 		"template":         vmReq.Template,
@@ -298,6 +298,11 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	var vmId string
 	err = c.Call("vm.create", params, &vmId)
 
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.StartVm(vmId)
 	if err != nil {
 		return nil, err
 	}

--- a/client/vm.go
+++ b/client/vm.go
@@ -236,6 +236,7 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 	destroyCloudConfigVdiAfterBoot := vmReq.DestroyCloudConfigVdiAfterBoot
 	if destroyCloudConfigVdiAfterBoot {
 		params["destroyCloudConfigVdiAfterBoot"] = destroyCloudConfigVdiAfterBoot
+		params["bootAfterCreate"] = true
 	}
 
 	videoram := vmReq.Videoram.Value
@@ -302,9 +303,12 @@ func (c *Client) CreateVm(vmReq Vm, createTime time.Duration) (*Vm, error) {
 		return nil, err
 	}
 
-	err = c.StartVm(vmId)
-	if err != nil {
-		return nil, err
+	bootAfterCreate := params["bootAfterCreate"].(bool)
+	if !bootAfterCreate {
+		err = c.StartVm(vmId)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = c.waitForModifyVm(vmId, vmReq.WaitForIps, createTime)

--- a/xoa/resource_xenorchestra_vm_test.go
+++ b/xoa/resource_xenorchestra_vm_test.go
@@ -1909,6 +1909,7 @@ resource "xenorchestra_vm" "bar" {
     network {
 	network_id = "${data.xenorchestra_network.network.id}"
     }
+    destroy_cloud_config_vdi_after_boot = true
 
     disk {
       sr_id = "%s"


### PR DESCRIPTION
Summary: Separate VM creation into create and start when possible

This is follow up to the conversation mentioned here (https://github.com/terra-farm/terraform-provider-xenorchestra/issues/263#issuecomment-1776649624). The goal is to merge this ahead of #263 and then update that branch to be compatible with it (I believe it will require some minor tweaks).

Testing Done: Jenkins job is passing

![screen](https://github.com/terra-farm/terraform-provider-xenorchestra/assets/5855593/1c904c26-48e7-4eeb-bbc2-b218dc207dd4)

