### PR TITLE
Pre download terraform cli to Jenkins and use `TF_ACC_TERRAFORM_PATH` to prevent disk space issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
       axes {
         axis {
           name 'TF_VERSION'
-          values 'v0.14.11', 'v1.6.5'
+          values 'terraform-v0.14.11', 'terraform-v1.6.6'
         }
       }
       stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,8 +32,6 @@ pipeline {
           steps {
             lock('xoa-test-runner') {
               sh 'cp /opt/terraform-provider-xenorchestra/testdata/images/alpine-virt-3.17.0-x86_64.iso xoa/testdata/alpine-virt-3.17.0-x86_64.iso'
-              sh 'echo ${XOA_RETRY_MAX_TIME}'
-              sh 'echo ${XOA_RETRY_MODE}'
               sh 'TF_VERSION=${TF_VERSION} make ci'
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,8 @@ pipeline {
           steps {
             lock('xoa-test-runner') {
               sh 'cp /opt/terraform-provider-xenorchestra/testdata/images/alpine-virt-3.17.0-x86_64.iso xoa/testdata/alpine-virt-3.17.0-x86_64.iso'
+              sh 'echo ${XOA_RETRY_MAX_TIME}'
+              sh 'echo ${XOA_RETRY_MODE}'
               sh 'TF_VERSION=${TF_VERSION} make ci'
             }
           }

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ testacc: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
 # to be removed from the repo. Add a target to enforce that the CI system
 # has copied that file into place before the tests run
 ci: xoa/testdata/alpine-virt-3.17.0-x86_64.iso
-	TF_ACC_TERRAFORM_VERSION=$(TF_VERSION) TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)
+	TF_ACC_TERRAFORM_PATH=/opt/terraform-provider-xenorchestra/bin/$(TF_VERSION) TF_ACC=1 gotestsum --debug --rerun-fails=5 --max-fails=15 --packages=./xoa  -- ./xoa -v -count=1 -timeout=$(TIMEOUT) -sweep=true -parallel=$(GOMAXPROCS)

--- a/client/client.go
+++ b/client/client.go
@@ -312,7 +312,6 @@ func (c *Client) Call(method string, params, result interface{}) error {
 			}
 
 			if c.IsRetryableError(*rpcErr) {
-				log.Printf("[INFO] Retrying rpc call `%s`\n", method)
 				return err
 			}
 

--- a/client/client.go
+++ b/client/client.go
@@ -312,6 +312,7 @@ func (c *Client) Call(method string, params, result interface{}) error {
 			}
 
 			if c.IsRetryableError(*rpcErr) {
+				log.Printf("[INFO] Retrying rpc call `%s`\n", method)
 				return err
 			}
 


### PR DESCRIPTION
Summary: Pre download terraform cli to Jenkins and use `TF_ACC_TERRAFORM_PATH` to prevent disk space issues

The terraform-plugin-sdk has the ability to automatically download a given terraform version when running acceptance tests. This seemed extremely flexible from the beginning, but it causes `/tmp` to fill up with multiple copies of the same cli (a given version is installed on each test run).

This also opens up the ability to add opentofu builds and will be completed in an upcoming PR.

Test plan: Build should succeed and not run Jenkins out of disk space