### PR TITLE
Upgrade latest terraform in CI job to latest version (v1.7.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
       axes {
         axis {
           name 'TF_VERSION'
-          values 'terraform-v0.14.11', 'terraform-v1.6.6'
+          values 'terraform-v0.14.11', 'terraform-v1.7.0'
         }
       }
       stages {


### PR DESCRIPTION
Summary: Upgrade latest terraform in CI job to latest version (v1.7.0)

This PR updates the latest terraform version in the jenkins job to v1.7.0 since it was released today.

Test plan: Jenkins job should pass on v1.7.0