### PR TITLE
Add xenstore support to the `xenorchestra_vm` resource

### DIFF
--- a/examples/resources/xenorchestra_vm/resource.tf
+++ b/examples/resources/xenorchestra_vm/resource.tf
@@ -58,6 +58,13 @@ resource "xenorchestra_vm" "bar" {
     timeouts {
       create = "20m"
     }
+
+    // Note: Xen Orchestra populates values within Xenstore and will need ignored via
+    // lifecycle ignore_changes or modeled in your terraform code
+    xenstore = {
+      key1 = "val1"
+      key2 = "val2"
+    }
 }
 
 # vm resource that uses wait_for_ip

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ddelnano/terraform-provider-xenorchestra/client"
@@ -408,6 +409,14 @@ $ xo-cli xo.getAllObjects filter='json:{"id": "cf7b5d7d-3cd5-6b7c-5025-5c935c8cd
 				},
 			},
 		},
+		"xenstore": &schema.Schema{
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Description: "The key value pairs to be populated in xenstore.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"tags": resourceTags(),
 	}
 }
@@ -566,7 +575,8 @@ func resourceVmCreate(d *schema.ResourceData, m interface{}) error {
 		Videoram: client.Videoram{
 			Value: d.Get("videoram").(int),
 		},
-		Vga: d.Get("vga").(string),
+		XenstoreData: d.Get("xenstore").(map[string]interface{}),
+		Vga:          d.Get("vga").(string),
 	}
 
 	affinityHost := d.Get("affinity_host").(string)
@@ -927,6 +937,23 @@ func resourceVmUpdate(d *schema.ResourceData, m interface{}) error {
 		vmReq.AffinityHost = &affinityHost
 	}
 
+	if d.HasChange("xenstore") {
+		xenstoreParams := map[string]interface{}{}
+		o, n := d.GetChange("xenstore")
+		oXs := o.(map[string]interface{})
+		nXs := n.(map[string]interface{})
+
+		for k, _ := range oXs {
+			xenstoreParams[k] = nil
+		}
+
+		for k, v := range nXs {
+			xenstoreParams[k] = v
+		}
+
+		vmReq.XenstoreData = xenstoreParams
+	}
+
 	haltPerformed := false
 
 	if haltForUpdates {
@@ -1185,8 +1212,27 @@ func recordToData(resource client.Vm, vifs []client.VIF, disks []client.Disk, cd
 			return err
 		}
 	}
+	filtered := filterXenstoreDataToVmData(resource.XenstoreData)
+	log.Printf("[DEBUG] Found the following xenstore data : %v after=%v\n", resource.XenstoreData, filtered)
+	if err := d.Set("xenstore", filtered); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func filterXenstoreDataToVmData(xenstore map[string]interface{}) map[string]interface{} {
+	filtered := map[string]interface{}{}
+	for key, value := range xenstore {
+		if strings.HasPrefix(key, "vm-data/") {
+			pieces := strings.SplitAfterN(key, "vm-data/", 2)
+			if len(pieces) != 2 {
+				continue
+			}
+			filtered[pieces[1]] = value
+		}
+	}
+	return filtered
 }
 
 func vmBlockedOperationsToList(v client.Vm) []string {


### PR DESCRIPTION
Summary: Add xenstore support to the `xenorchestra_vm` resource

This is the final part for completing #261. Note this currently relies on https://github.com/vatesfr/xen-orchestra/pull/7316, which is not yet in a Xen Orchestra release. Merging this change must be held off until that release is available. On this topic, it would be nice for the provider to be aware of the XO server version and constraints for a given feature (Xenstore requires  it's connected to and warn a user that the given attribute requires an XO server upgrade.

Test plan: Verified the following
- [x] New test verifies expected behavior with my locally patched XO server
- [ ] The Xen Orchestra server required for this change has been released (>= 5.91.0 -- specific release version still tbd but that should be the next minor version)