### PR TITLE
fix Issue with VM disk mapping from template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.22.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
-	github.com/vatesfr/xenorchestra-go-sdk v1.5.0
+	github.com/vatesfr/xenorchestra-go-sdk v1.5.1
 )
 
 require (
@@ -47,7 +47,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.23.0 // indirect
 	github.com/hashicorp/terraform-json v0.25.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.27.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vatesfr/xenorchestra-go-sdk v1.5.0 h1:tJNrxDUip1kKw1J8lLQXMdnnIH/ijqx1JEOpeyZIMio=
-github.com/vatesfr/xenorchestra-go-sdk v1.5.0/go.mod h1:AVCFAYphKhw2qRyvRn2cYLbC6SRssnbVOQI+YK+EunU=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1-0.20250922140055-8c35146b3797 h1:FmRr0lrftaWOcOknVqhiDuBYIc7bWE5sG6IyuOAwR14=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1-0.20250922140055-8c35146b3797/go.mod h1:AVCFAYphKhw2qRyvRn2cYLbC6SRssnbVOQI+YK+EunU=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1-0.20250923093445-51e24665fd9e h1:jvKJZN2p7YrC80c95OEiBzNzvcWU84n9ZVSUimvt+UA=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1-0.20250923093445-51e24665fd9e/go.mod h1:AVCFAYphKhw2qRyvRn2cYLbC6SRssnbVOQI+YK+EunU=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1 h1:oxBTaQmKVHXPIe2Cs2eYpfLXtAIpi66Q4OV/H7AQzDo=
+github.com/vatesfr/xenorchestra-go-sdk v1.5.1/go.mod h1:AVCFAYphKhw2qRyvRn2cYLbC6SRssnbVOQI+YK+EunU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -832,8 +832,8 @@ func resourceVmUpdateContext(ctx context.Context, d *schema.ResourceData, m inte
 		removals := expandNetworks(oSet.Difference(nSet).List())
 		tflog.Debug(ctx, "Found network removals", map[string]interface{}{
 			"removals":     oSet.Difference(nSet).List(),
-			"previous_set": oSet,
-			"new_set":      nSet,
+			"previous_set": oSet.List(),
+			"new_set":      nSet.List(),
 		})
 		for _, removal := range removals {
 			// We will process the updates with the additons so we only need to deal with
@@ -854,8 +854,8 @@ func resourceVmUpdateContext(ctx context.Context, d *schema.ResourceData, m inte
 		additions := sortNetworksByDevice(expandNetworks(nSet.Difference(oSet).List()))
 		tflog.Debug(ctx, "Found network additions", map[string]interface{}{
 			"additions":    nSet.Difference(oSet).List(),
-			"previous_set": oSet,
-			"new_set":      nSet,
+			"previous_set": oSet.List(),
+			"new_set":      nSet.List(),
 		})
 		for _, addition := range additions {
 			updateVif, shouldAttach := shouldUpdateVif(*addition, expandNetworks(oSet.List()))
@@ -912,8 +912,8 @@ func resourceVmUpdateContext(ctx context.Context, d *schema.ResourceData, m inte
 		removals := expandDisks(oSet.Difference(nSet).List())
 		tflog.Debug(ctx, "Found disk removals", map[string]interface{}{
 			"removals":     oSet.Difference(nSet).List(),
-			"previous_set": oSet,
-			"new_set":      nSet,
+			"previous_set": oSet.List(),
+			"new_set":      nSet.List(),
 		})
 		for _, removal := range removals {
 			var actions *[]updateDiskActions
@@ -1035,8 +1035,8 @@ func resourceVmUpdateContext(ctx context.Context, d *schema.ResourceData, m inte
 		additions := sortDiskByPostion(expandDisks(nSet.Difference(oSet).List()))
 		tflog.Debug(ctx, "Found disk additions", map[string]interface{}{
 			"additions":    nSet.Difference(oSet).List(),
-			"previous_set": oSet,
-			"new_set":      nSet,
+			"previous_set": oSet.List(),
+			"new_set":      nSet.List(),
 		})
 		for _, disk := range additions {
 


### PR DESCRIPTION
The fix is in the [xenorchestra-go-sdk#37](https://github.com/vatesfr/xenorchestra-go-sdk/pull/37)

Fixes #361

This PR also fixes a bug relating to resizing existing template disks to a smaller size. Until now, this was possible, but it posed a potential risk of data loss. This will no longer be possible with the PR.

Improved behaviour when creating a VM from a template:
- All existing disks in the template are used if they are declared in the TF plan.
- All unused disks in the template are deleted to avoid inconsistency between the TF plan and the actual state.
- It is no longer possible to resize existing template disks to a smaller size.