### PR TITLE
fix: add template field value to VM resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/vatesfr/xenorchestra-go-sdk v1.16.0
+	github.com/vatesfr/xenorchestra-go-sdk v1.17.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vatesfr/xenorchestra-go-sdk v1.16.0 h1:PyAdRE1vFJZ0JLch+yviFzfNV3M1K/fkOsdSeHZxfSo=
-github.com/vatesfr/xenorchestra-go-sdk v1.16.0/go.mod h1:fTF8G7F6f6145Ekv1NQI/S9zVRoAmW0xZnFAymU9Pjg=
+github.com/vatesfr/xenorchestra-go-sdk v1.17.0 h1:r5uyeThiARh1I2fUqVRH8auGU6WK+ujEChT6WPej4rA=
+github.com/vatesfr/xenorchestra-go-sdk v1.17.0/go.mod h1:OP2NfSLyqmFMfITRU8NoMMstitZ4nLTBXPVoLzRQ2Uo=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -1299,6 +1299,9 @@ func recordToData(ctx context.Context, resource client.Vm, vifs []client.VIF, di
 	d.Set("name_description", resource.NameDescription)
 	d.Set("high_availability", resource.HA)
 	d.Set("auto_poweron", resource.AutoPoweron)
+	if resource.Template != "" {
+		d.Set("template", resource.Template)
+	}
 	if resource.ResourceSet != nil {
 		d.Set("resource_set", resource.ResourceSet.Id)
 	} else {

--- a/xoa/resource_xenorchestra_vm.go
+++ b/xoa/resource_xenorchestra_vm.go
@@ -78,8 +78,13 @@ func resourceVm() *schema.Resource {
 func vmCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	// Check power state and cloudConfig constraints
 	destroyCloudConfig := diff.Get("destroy_cloud_config_vdi_after_boot").(bool)
+	cloudConfig := diff.Get("cloud_config").(string)
 	powerState := diff.Get("power_state").(string)
 	powerStateChanged := diff.HasChange("power_state")
+
+	if destroyCloudConfig && cloudConfig == "" {
+		return fmt.Errorf("cloud_config must be specified when destroy_cloud_config_vdi_after_boot is set to `true`")
+	}
 
 	if powerStateChanged && destroyCloudConfig && powerState != client.RunningPowerState {
 		return fmt.Errorf("power_state must be `%s` when destroy_cloud_config_vdi_after_boot set to `true`", client.RunningPowerState)
@@ -202,12 +207,9 @@ func resourceVmSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"destroy_cloud_config_vdi_after_boot": &schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			RequiredWith: []string{
-				"cloud_config",
-			},
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
 			ForceNew:    true,
 			Description: "Determines whether the cloud config VDI should be deleted once the VM has booted. Defaults to `false`. If set to `true`, power_state must be set to `Running`.",
 		},
@@ -1257,6 +1259,10 @@ func RecordImportContext(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	err = recordToData(ctx, *vm, vifs, disks, cdroms, d)
+
+	if err := d.Set("destroy_cloud_config_vdi_after_boot", false); err != nil {
+		return rd, err
+	}
 
 	return rd, err
 }


### PR DESCRIPTION
Linked issues #100 #335 

This PR fix the fact that it was impossible to import a vm without modifying manually or recreating it.

Indeed, the `template` and the `destroy_cloud_config_vdi_after_boot` values were null at the import.

I set them to false at the import, and `cloud_config` is no longer necessary when `destroy_cloud_config_vdi_after_boot` is set to `false`

Now, this is the current result of tf plan after the import :
```txt
$ tf plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vatesfr/xenorchestra in <my-dev-space>
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
xenorchestra_vm.imported: Refreshing state... [id=<id>]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # xenorchestra_vm.imported will be updated in-place
  ~ resource "xenorchestra_vm" "imported" {
      + clone_type                          = "fast"
      + core_os                             = false
      + cpu_cap                             = 0
      + cpu_weight                          = 0
        id                                  = "<id>"
        tags                                = []
        # (23 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

Applying this will make this patch (serial is just a number that is incremented each version) : 
```diff
4c4
<   "serial": 45,
---
>   "serial": 43,
21c21
<             "clone_type": "fast",
---
>             "clone_type": null,
24c24
<             "core_os": false,
---
>             "core_os": null,
26,27c26,27
<             "cpu_cap": 0,
<             "cpu_weight": 0,
---
>             "cpu_cap": null,
>             "cpu_weight": null,
```

I think I will fix this in an other PR to have this result directly : 
```
$ tf apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vatesfr/xenorchestra in <my-dev-space>
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
xenorchestra_vm.imported: Refreshing state... [id=<id>]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.